### PR TITLE
Reintroduce language key to data files

### DIFF
--- a/data/gb/cy/countries-of-birth.json
+++ b/data/gb/cy/countries-of-birth.json
@@ -1,254 +1,758 @@
 [
-    "Lloegr",
-    "Cymru",
-    "Yr Alban",
-    "Gogledd Iwerddon",
-    "Gweriniaeth Iwerddon",
-    "Affganistan",
-    "Ynysoedd Åland",
-    "Albania",
-    "Algeria",
-    "Samoa Americanaidd",
-    "Andorra",
-    "Angola",
-    "Anguilla",
-    "Antigua a Barbuda",
-    "Ariannin",
-    "Armenia",
-    "Aruba",
-    "Awstralia",
-    "Awstria",
-    "Azerbaijan",
-    "Barbados",
-    "Bahrain",
-    "Bangladesh",
-    "Belarws",
-    "Gwlad Belg",
-    "Belize",
-    "Benin",
-    "Bermuda",
-    "Bhutan",
-    "Bolifia",
-    "Bonaire, Sint Eustatius a Saba",
-    "Bosnia a Herzegovina",
-    "Botswana",
-    "Ynys Bouvet",
-    "Brasil",
-    "Tiriogaeth Brydeinig Cefnfor India",
-    "Ynysoedd Prydeinig y Wyryf",
-    "Brunei",
-    "Bwlgaria",
-    "Burkina Faso",
-    "Burundi",
-    "Cambodia",
-    "Cameroon",
-    "Canada",
-    "Yr Ynysoedd Dedwydd",
-    "Cabo Verde",
-    "Ynysoedd Cayman",
-    "Gweriniaeth Canol Affrica",
-    "Chad",
-    "Ynysoedd y Sianel",
-    "Chile",
-    "Tsieina",
-    "Ynys y Nadolig",
-    "Ynysoedd Cocos (Keeling)",
-    "Colombia",
-    "Comoros",
-    "Congo",
-    "Congo (Gweriniaeth Ddemocrataidd)",
-    "Ynysoedd Cook",
-    "Costa Rica",
-    "Croatia",
-    "Cuba",
-    "Curaçao",
-    "Cyprus",
-    "Czechia",
-    "Denmarc",
-    "Djibouti",
-    "Dominica",
-    "Gweriniaeth Dominica",
-    "Dwyrain Timor",
-    "Ecuador",
-    "Yr Aifft",
-    "El Salvador",
-    "Guinea Gyhydeddol",
-    "Eritrea",
-    "Estonia",
-    "Eswatini",
-    "Ethiopia",
-    "Ynysoedd Falkland (Malvinas)",
-    "Ynysoedd Ffaro",
-    "Ffiji",
-    "Y Ffindir",
-    "Ffrainc",
-    "Guiana Ffrengig",
-    "Polynesia Ffrengig",
-    "Y Tiriogaethau Deheuol Ffrengig",
-    "Gabon",
-    "Georgia",
-    "Yr Almaen",
-    "Ghana",
-    "Gibraltar",
-    "Gwlad Groeg",
-    "Kalaallit Nunaat (Greenland)",
-    "Grenada",
-    "Guadeloupe",
-    "Guam",
-    "Guatemala",
-    "Guinea",
-    "Guinea-Bissau",
-    "Guyana",
-    "Haiti",
-    "Ynysoedd Heard ac Ynysoedd McDonald",
-    "Honduras",
-    "Hong Kong",
-    "Hwngari",
-    "Gwlad yr Iâ",
-    "India",
-    "Indonesia",
-    "Iran",
-    "Irac",
-    "Ynys Manaw",
-    "Israel",
-    "Yr Eidal",
-    "Y Traeth Ifori",
-    "Jamaica",
-    "Japan",
-    "Gwlad yr Iorddonen",
-    "Kazakhstan",
-    "Kenya",
-    "Kiribati",
-    "Kosovo",
-    "Kuwait",
-    "Kyrgyzstan",
-    "Laos",
-    "Latfia",
-    "Libanus",
-    "Lesotho",
-    "Liberia",
-    "Libya",
-    "Liechtenstein",
-    "Lithwania",
-    "Lwcsembwrg",
-    "Macao",
-    "Madagasgar",
-    "Malawi",
-    "Malaysia",
-    "Maldives",
-    "Mali",
-    "Malta",
-    "Ynysoedd Marshall",
-    "Martinique",
-    "Mauritania",
-    "Mauritius",
-    "Mayotte",
-    "Mecsico",
-    "Micronesia",
-    "Moldofa",
-    "Monaco",
-    "Mongolia",
-    "Montenegro",
-    "Montserrat",
-    "Moroco",
-    "Mozambique",
-    "Myanmar (Burma)",
-    "Namibia",
-    "Nauru",
-    "Nepal",
-    "Yr Iseldiroedd",
-    "Caledonia Newydd",
-    "Seland Newydd",
-    "Nicaragua",
-    "Niger",
-    "Nigeria",
-    "Niue",
-    "Ynys Norfolk",
-    "Gogledd Korea",
-    "Gogledd Macedonia",
-    "Ynysoedd Gogleddol Mariana",
-    "Norwy",
-    "Tiriogaethau Meddianedig Palesteina",
-    "Oman",
-    "Pacistan",
-    "Palau",
-    "Panama",
-    "Papua Guinea Newydd",
-    "Paraguay",
-    "Periw",
-    "Pilipinas (Ynysoedd Philippines)",
-    "Ynysoedd Pitcairn, Henderson, Ducie ac Oeno",
-    "Gwlad Pwyl",
-    "Portiwgal",
-    "Puerto Rico",
-    "Qatar",
-    "Réunion",
-    "Rwmania",
-    "Rwsia",
-    "Rwanda",
-    "Saint Martin (Rhan Ffrainc)",
-    "Samoa",
-    "San Marino",
-    "Sao Tome a Principe",
-    "Saudi Arabia",
-    "Senegal",
-    "Serbia",
-    "Seychelles",
-    "Sierra Leone",
-    "Singapore",
-    "Sint Maarten (Rhan yr Iseldiroedd)",
-    "Slofacia",
-    "Slofenia",
-    "Ynysoedd Solomon",
-    "Somalia",
-    "De Affrica",
-    "De Georgia ac Ynysoedd Sandwich y De",
-    "De Korea",
-    "De Sudan",
-    "Sbaen (gan gynnwys Ynysoedd Baleares)",
-    "Sri Lanka",
-    "St Barthélemy",
-    "St Helena, Ascension a Tristan da Cunha",
-    "St Kitts a Nevis",
-    "St Lucia",
-    "St Pierre a Miquelon",
-    "St Vincent a'r Grenadines",
-    "Sudan",
-    "Suriname",
-    "Svalbard a Jan Mayen",
-    "Sweden",
-    "Y Swistir",
-    "Syria",
-    "Taiwan",
-    "Tajikistan",
-    "Tanzania",
-    "Gwlad Thai",
-    "Y Bahamas",
-    "Y Gambia",
-    "Togo",
-    "Tokelau",
-    "Tonga",
-    "Trinidad a Tobago",
-    "Tunisia",
-    "Twrci",
-    "Turkmenistan",
-    "Ynysoedd Turks a Caicos",
-    "Tuvalu",
-    "Uganda",
-    "Ukrain",
-    "Yr Emiraethau Arabaidd Unedig",
-    "Mân-ynysoedd Pellennig yr Unol Daleithiau",
-    "Unol Daleithiau America",
-    "Ynysoedd Americanaidd Y Wyryf",
-    "Uruguay",
-    "Uzbekistan",
-    "Vanuatu",
-    "Dinas y Fatican",
-    "Venezuela",
-    "Fiet-nam",
-    "Wallis a Futuna",
-    "Gorllewin Sahara",
-    "Yemen",
-    "Zambia",
-    "Zimbabwe"
+    {
+        "cy": "Lloegr"
+    },
+    {
+        "cy": "Cymru"
+    },
+    {
+        "cy": "Yr Alban"
+    },
+    {
+        "cy": "Gogledd Iwerddon"
+    },
+    {
+        "cy": "Gweriniaeth Iwerddon"
+    },
+    {
+        "cy": "Affganistan"
+    },
+    {
+        "cy": "Ynysoedd Åland"
+    },
+    {
+        "cy": "Albania"
+    },
+    {
+        "cy": "Algeria"
+    },
+    {
+        "cy": "Samoa Americanaidd"
+    },
+    {
+        "cy": "Andorra"
+    },
+    {
+        "cy": "Angola"
+    },
+    {
+        "cy": "Anguilla"
+    },
+    {
+        "cy": "Antigua a Barbuda"
+    },
+    {
+        "cy": "Ariannin"
+    },
+    {
+        "cy": "Armenia"
+    },
+    {
+        "cy": "Aruba"
+    },
+    {
+        "cy": "Awstralia"
+    },
+    {
+        "cy": "Awstria"
+    },
+    {
+        "cy": "Azerbaijan"
+    },
+    {
+        "cy": "Barbados"
+    },
+    {
+        "cy": "Bahrain"
+    },
+    {
+        "cy": "Bangladesh"
+    },
+    {
+        "cy": "Belarws"
+    },
+    {
+        "cy": "Gwlad Belg"
+    },
+    {
+        "cy": "Belize"
+    },
+    {
+        "cy": "Benin"
+    },
+    {
+        "cy": "Bermuda"
+    },
+    {
+        "cy": "Bhutan"
+    },
+    {
+        "cy": "Bolifia"
+    },
+    {
+        "cy": "Bonaire, Sint Eustatius a Saba"
+    },
+    {
+        "cy": "Bosnia a Herzegovina"
+    },
+    {
+        "cy": "Botswana"
+    },
+    {
+        "cy": "Ynys Bouvet"
+    },
+    {
+        "cy": "Brasil"
+    },
+    {
+        "cy": "Tiriogaeth Brydeinig Cefnfor India"
+    },
+    {
+        "cy": "Ynysoedd Prydeinig y Wyryf"
+    },
+    {
+        "cy": "Brunei"
+    },
+    {
+        "cy": "Bwlgaria"
+    },
+    {
+        "cy": "Burkina Faso"
+    },
+    {
+        "cy": "Burundi"
+    },
+    {
+        "cy": "Cambodia"
+    },
+    {
+        "cy": "Cameroon"
+    },
+    {
+        "cy": "Canada"
+    },
+    {
+        "cy": "Yr Ynysoedd Dedwydd"
+    },
+    {
+        "cy": "Cabo Verde"
+    },
+    {
+        "cy": "Ynysoedd Cayman"
+    },
+    {
+        "cy": "Gweriniaeth Canol Affrica"
+    },
+    {
+        "cy": "Chad"
+    },
+    {
+        "cy": "Ynysoedd y Sianel"
+    },
+    {
+        "cy": "Chile"
+    },
+    {
+        "cy": "Tsieina"
+    },
+    {
+        "cy": "Ynys y Nadolig"
+    },
+    {
+        "cy": "Ynysoedd Cocos (Keeling)"
+    },
+    {
+        "cy": "Colombia"
+    },
+    {
+        "cy": "Comoros"
+    },
+    {
+        "cy": "Congo"
+    },
+    {
+        "cy": "Congo (Gweriniaeth Ddemocrataidd)"
+    },
+    {
+        "cy": "Ynysoedd Cook"
+    },
+    {
+        "cy": "Costa Rica"
+    },
+    {
+        "cy": "Croatia"
+    },
+    {
+        "cy": "Cuba"
+    },
+    {
+        "cy": "Curaçao"
+    },
+    {
+        "cy": "Cyprus"
+    },
+    {
+        "cy": "Czechia"
+    },
+    {
+        "cy": "Denmarc"
+    },
+    {
+        "cy": "Djibouti"
+    },
+    {
+        "cy": "Dominica"
+    },
+    {
+        "cy": "Gweriniaeth Dominica"
+    },
+    {
+        "cy": "Dwyrain Timor"
+    },
+    {
+        "cy": "Ecuador"
+    },
+    {
+        "cy": "Yr Aifft"
+    },
+    {
+        "cy": "El Salvador"
+    },
+    {
+        "cy": "Guinea Gyhydeddol"
+    },
+    {
+        "cy": "Eritrea"
+    },
+    {
+        "cy": "Estonia"
+    },
+    {
+        "cy": "Eswatini"
+    },
+    {
+        "cy": "Ethiopia"
+    },
+    {
+        "cy": "Ynysoedd Falkland (Malvinas)"
+    },
+    {
+        "cy": "Ynysoedd Ffaro"
+    },
+    {
+        "cy": "Ffiji"
+    },
+    {
+        "cy": "Y Ffindir"
+    },
+    {
+        "cy": "Ffrainc"
+    },
+    {
+        "cy": "Guiana Ffrengig"
+    },
+    {
+        "cy": "Polynesia Ffrengig"
+    },
+    {
+        "cy": "Y Tiriogaethau Deheuol Ffrengig"
+    },
+    {
+        "cy": "Gabon"
+    },
+    {
+        "cy": "Georgia"
+    },
+    {
+        "cy": "Yr Almaen"
+    },
+    {
+        "cy": "Ghana"
+    },
+    {
+        "cy": "Gibraltar"
+    },
+    {
+        "cy": "Gwlad Groeg"
+    },
+    {
+        "cy": "Kalaallit Nunaat (Greenland)"
+    },
+    {
+        "cy": "Grenada"
+    },
+    {
+        "cy": "Guadeloupe"
+    },
+    {
+        "cy": "Guam"
+    },
+    {
+        "cy": "Guatemala"
+    },
+    {
+        "cy": "Guinea"
+    },
+    {
+        "cy": "Guinea-Bissau"
+    },
+    {
+        "cy": "Guyana"
+    },
+    {
+        "cy": "Haiti"
+    },
+    {
+        "cy": "Ynysoedd Heard ac Ynysoedd McDonald"
+    },
+    {
+        "cy": "Honduras"
+    },
+    {
+        "cy": "Hong Kong"
+    },
+    {
+        "cy": "Hwngari"
+    },
+    {
+        "cy": "Gwlad yr Iâ"
+    },
+    {
+        "cy": "India"
+    },
+    {
+        "cy": "Indonesia"
+    },
+    {
+        "cy": "Iran"
+    },
+    {
+        "cy": "Irac"
+    },
+    {
+        "cy": "Ynys Manaw"
+    },
+    {
+        "cy": "Israel"
+    },
+    {
+        "cy": "Yr Eidal"
+    },
+    {
+        "cy": "Y Traeth Ifori"
+    },
+    {
+        "cy": "Jamaica"
+    },
+    {
+        "cy": "Japan"
+    },
+    {
+        "cy": "Gwlad yr Iorddonen"
+    },
+    {
+        "cy": "Kazakhstan"
+    },
+    {
+        "cy": "Kenya"
+    },
+    {
+        "cy": "Kiribati"
+    },
+    {
+        "cy": "Kosovo"
+    },
+    {
+        "cy": "Kuwait"
+    },
+    {
+        "cy": "Kyrgyzstan"
+    },
+    {
+        "cy": "Laos"
+    },
+    {
+        "cy": "Latfia"
+    },
+    {
+        "cy": "Libanus"
+    },
+    {
+        "cy": "Lesotho"
+    },
+    {
+        "cy": "Liberia"
+    },
+    {
+        "cy": "Libya"
+    },
+    {
+        "cy": "Liechtenstein"
+    },
+    {
+        "cy": "Lithwania"
+    },
+    {
+        "cy": "Lwcsembwrg"
+    },
+    {
+        "cy": "Macao"
+    },
+    {
+        "cy": "Madagasgar"
+    },
+    {
+        "cy": "Malawi"
+    },
+    {
+        "cy": "Malaysia"
+    },
+    {
+        "cy": "Maldives"
+    },
+    {
+        "cy": "Mali"
+    },
+    {
+        "cy": "Malta"
+    },
+    {
+        "cy": "Ynysoedd Marshall"
+    },
+    {
+        "cy": "Martinique"
+    },
+    {
+        "cy": "Mauritania"
+    },
+    {
+        "cy": "Mauritius"
+    },
+    {
+        "cy": "Mayotte"
+    },
+    {
+        "cy": "Mecsico"
+    },
+    {
+        "cy": "Micronesia"
+    },
+    {
+        "cy": "Moldofa"
+    },
+    {
+        "cy": "Monaco"
+    },
+    {
+        "cy": "Mongolia"
+    },
+    {
+        "cy": "Montenegro"
+    },
+    {
+        "cy": "Montserrat"
+    },
+    {
+        "cy": "Moroco"
+    },
+    {
+        "cy": "Mozambique"
+    },
+    {
+        "cy": "Myanmar (Burma)"
+    },
+    {
+        "cy": "Namibia"
+    },
+    {
+        "cy": "Nauru"
+    },
+    {
+        "cy": "Nepal"
+    },
+    {
+        "cy": "Yr Iseldiroedd"
+    },
+    {
+        "cy": "Caledonia Newydd"
+    },
+    {
+        "cy": "Seland Newydd"
+    },
+    {
+        "cy": "Nicaragua"
+    },
+    {
+        "cy": "Niger"
+    },
+    {
+        "cy": "Nigeria"
+    },
+    {
+        "cy": "Niue"
+    },
+    {
+        "cy": "Ynys Norfolk"
+    },
+    {
+        "cy": "Gogledd Korea"
+    },
+    {
+        "cy": "Gogledd Macedonia"
+    },
+    {
+        "cy": "Ynysoedd Gogleddol Mariana"
+    },
+    {
+        "cy": "Norwy"
+    },
+    {
+        "cy": "Tiriogaethau Meddianedig Palesteina"
+    },
+    {
+        "cy": "Oman"
+    },
+    {
+        "cy": "Pacistan"
+    },
+    {
+        "cy": "Palau"
+    },
+    {
+        "cy": "Panama"
+    },
+    {
+        "cy": "Papua Guinea Newydd"
+    },
+    {
+        "cy": "Paraguay"
+    },
+    {
+        "cy": "Periw"
+    },
+    {
+        "cy": "Pilipinas (Ynysoedd Philippines)"
+    },
+    {
+        "cy": "Ynysoedd Pitcairn, Henderson, Ducie ac Oeno"
+    },
+    {
+        "cy": "Gwlad Pwyl"
+    },
+    {
+        "cy": "Portiwgal"
+    },
+    {
+        "cy": "Puerto Rico"
+    },
+    {
+        "cy": "Qatar"
+    },
+    {
+        "cy": "Réunion"
+    },
+    {
+        "cy": "Rwmania"
+    },
+    {
+        "cy": "Rwsia"
+    },
+    {
+        "cy": "Rwanda"
+    },
+    {
+        "cy": "Saint Martin (Rhan Ffrainc)"
+    },
+    {
+        "cy": "Samoa"
+    },
+    {
+        "cy": "San Marino"
+    },
+    {
+        "cy": "Sao Tome a Principe"
+    },
+    {
+        "cy": "Saudi Arabia"
+    },
+    {
+        "cy": "Senegal"
+    },
+    {
+        "cy": "Serbia"
+    },
+    {
+        "cy": "Seychelles"
+    },
+    {
+        "cy": "Sierra Leone"
+    },
+    {
+        "cy": "Singapore"
+    },
+    {
+        "cy": "Sint Maarten (Rhan yr Iseldiroedd)"
+    },
+    {
+        "cy": "Slofacia"
+    },
+    {
+        "cy": "Slofenia"
+    },
+    {
+        "cy": "Ynysoedd Solomon"
+    },
+    {
+        "cy": "Somalia"
+    },
+    {
+        "cy": "De Affrica"
+    },
+    {
+        "cy": "De Georgia ac Ynysoedd Sandwich y De"
+    },
+    {
+        "cy": "De Korea"
+    },
+    {
+        "cy": "De Sudan"
+    },
+    {
+        "cy": "Sbaen (gan gynnwys Ynysoedd Baleares)"
+    },
+    {
+        "cy": "Sri Lanka"
+    },
+    {
+        "cy": "St Barthélemy"
+    },
+    {
+        "cy": "St Helena, Ascension a Tristan da Cunha"
+    },
+    {
+        "cy": "St Kitts a Nevis"
+    },
+    {
+        "cy": "St Lucia"
+    },
+    {
+        "cy": "St Pierre a Miquelon"
+    },
+    {
+        "cy": "St Vincent a'r Grenadines"
+    },
+    {
+        "cy": "Sudan"
+    },
+    {
+        "cy": "Suriname"
+    },
+    {
+        "cy": "Svalbard a Jan Mayen"
+    },
+    {
+        "cy": "Sweden"
+    },
+    {
+        "cy": "Y Swistir"
+    },
+    {
+        "cy": "Syria"
+    },
+    {
+        "cy": "Taiwan"
+    },
+    {
+        "cy": "Tajikistan"
+    },
+    {
+        "cy": "Tanzania"
+    },
+    {
+        "cy": "Gwlad Thai"
+    },
+    {
+        "cy": "Y Bahamas"
+    },
+    {
+        "cy": "Y Gambia"
+    },
+    {
+        "cy": "Togo"
+    },
+    {
+        "cy": "Tokelau"
+    },
+    {
+        "cy": "Tonga"
+    },
+    {
+        "cy": "Trinidad a Tobago"
+    },
+    {
+        "cy": "Tunisia"
+    },
+    {
+        "cy": "Twrci"
+    },
+    {
+        "cy": "Turkmenistan"
+    },
+    {
+        "cy": "Ynysoedd Turks a Caicos"
+    },
+    {
+        "cy": "Tuvalu"
+    },
+    {
+        "cy": "Uganda"
+    },
+    {
+        "cy": "Ukrain"
+    },
+    {
+        "cy": "Yr Emiraethau Arabaidd Unedig"
+    },
+    {
+        "cy": "Mân-ynysoedd Pellennig yr Unol Daleithiau"
+    },
+    {
+        "cy": "Unol Daleithiau America"
+    },
+    {
+        "cy": "Ynysoedd Americanaidd Y Wyryf"
+    },
+    {
+        "cy": "Uruguay"
+    },
+    {
+        "cy": "Uzbekistan"
+    },
+    {
+        "cy": "Vanuatu"
+    },
+    {
+        "cy": "Dinas y Fatican"
+    },
+    {
+        "cy": "Venezuela"
+    },
+    {
+        "cy": "Fiet-nam"
+    },
+    {
+        "cy": "Wallis a Futuna"
+    },
+    {
+        "cy": "Gorllewin Sahara"
+    },
+    {
+        "cy": "Yemen"
+    },
+    {
+        "cy": "Zambia"
+    },
+    {
+        "cy": "Zimbabwe"
+    }
 ]

--- a/data/gb/cy/ethnic-groups.json
+++ b/data/gb/cy/ethnic-groups.json
@@ -1,182 +1,542 @@
 [
-    "Affganaidd/Afghanaidd",
-    "Affricanaidd",
-    "Affricanaidd Americanaidd",
-    "Affricanaidd Asiaidd",
-    "Affricanaidd Caribïaidd",
-    "Albaniaidd",
-    "Algeraidd",
-    "Americanaidd",
-    "Eingl-Indiaidd",
-    "Eingl-Wyddelig",
-    "Eingl-Eidalaidd",
-    "Eingl-Sacsonaidd",
-    "Arabaidd",
-    "Archentaidd",
-    "Armenaidd",
-    "Asiaidd",
-    "Asiaidd Prydeinig",
-    "Asiaidd Seisnig",
-    "Asiaidd o Ogledd Iwerddon",
-    "Asiaidd Albanaidd",
-    "Asiaidd Cymreig",
-    "Asyriaidd",
-    "Awstralaidd",
-    "Awstriaidd",
-    "Baltig",
-    "Bangladeshaidd",
-    "Belarwsiaidd",
-    "Belgaidd",
-    "Berberaidd",
-    "Du Affricanaidd",
-    "Du Prydeinig",
-    "Du Caribïaidd",
-    "Du Seisnig",
-    "Du o Ogledd Iwerddon",
-    "Du Albanaidd",
-    "Du Cymreig",
-    "Bosniaidd",
-    "Brasilaidd",
-    "Prydeinig",
-    "Prydeinig Indiaidd",
-    "Prydeinig Pacistanaidd",
-    "Bwlgaraidd",
-    "Byrmanaidd neu Myanma/Burmanaidd neu Myanma",
-    "Cambodiaidd",
-    "Canadaidd",
-    "Caribïaidd",
-    "Celtaidd",
-    "Canol Ewropeaidd",
-    "Chileaidd/Tsileaidd",
-    "Tsieineaidd/Chineaidd",
-    "Colombiaidd",
-    "Congolaidd",
-    "Cernywaidd",
-    "Croataidd",
-    "Cypraidd",
-    "Tsiecaidd",
-    "Danaidd",
-    "Iseldiraidd",
-    "Dwyrain Affricanaidd",
-    "Dwyrain Ewropeaidd",
-    "Eelam Tamil",
-    "Eritreaidd",
-    "Ethiopaidd",
-    "Eifftaidd",
-    "Seisnig",
-    "Estonaidd",
-    "Ewrasiaidd/Eurasiaidd",
-    "Ewropeaidd",
-    "Ffijïaidd",
-    "Ffilipinaidd",
-    "Ffinnaidd",
-    "Ffrengig",
-    "Georgaidd",
-    "Almaenaidd",
-    "Ghanaidd",
-    "Goaidd",
-    "Groegaidd",
-    "Groegaidd Cypraidd/Cypraidd Groegaidd",
-    "Gurkha/Gyrca",
-    "Gaianaidd/Guyanaidd",
-    "Sipsi",
-    "Helenaidd",
-    "Sbaenig/Hisbaenaidd",
-    "Hwngaraidd",
-    "Islandaidd",
-    "Indiaidd",
-    "Indonesaidd",
-    "Iranaidd",
-    "Iracaidd",
-    "Gwyddelig",
-    "Teithiwr Gwyddelig",
-    "Israelaidd",
-    "Eidalaidd",
-    "Jamaicaidd",
-    "Japaneaidd/Siapaneaidd",
-    "Iddewig",
-    "Kashmiraidd/Cashmiraidd",
-    "Kazakh",
-    "Kenyaidd/Cenyaidd",
-    "Koreaidd/Coreaidd",
-    "Kosofaidd/Cosofaidd",
-    "Cwrdaidd Kurdaidd/Kwrdaidd",
-    "Lladin Americanaidd",
-    "Latino",
-    "Latfiaidd",
-    "Libanaidd/Lebanaidd",
-    "Lithwanaidd",
-    "Macedonaidd",
-    "Malayaidd",
-    "Malaysiaidd",
-    "Maltaidd",
-    "Manawaidd",
-    "Mawrisaidd/Mauritaidd",
-    "Mediteranaidd",
-    "Mecsicanaidd/Mexicanaidd",
-    "O'r Dwyrain Canol",
-    "Mongolaidd",
-    "Morocaidd",
-    "Nepalaidd",
-    "O Seland Newydd",
-    "Nigeriaidd (Nigeria)",
-    "Nigeraidd (Niger)",
-    "Nordig",
-    "Gogledd Affricanaidd",
-    "Gogledd Americanaidd",
-    "Gogledd Ewropeaidd",
-    "Gwyddelig Gogledd Iwerddon",
-    "Norwyaidd",
-    "Pacistanaidd",
-    "Persiaidd",
-    "Ffilipinaidd",
-    "Pwylaidd",
-    "Portiwgeaidd",
-    "Pwnjabaidd/Punjabaidd",
-    "Roma",
-    "Rwmanaidd/Romanaidd",
-    "Rwsiaidd",
-    "São Tomeaidd",
-    "Sgandinafaidd",
-    "Albanaidd",
-    "Serbaidd",
-    "Dyn Sioe",
-    "Person Sioe",
-    "Menyw Sioe",
-    "Sicaidd/Sikhaidd",
-    "Sinhalesaidd",
-    "Slafig",
-    "Slofacaidd",
-    "Slofenaidd",
-    "Somali",
-    "Somalilandaidd",
-    "De Affricanaidd",
-    "De Americanaidd",
-    "Asiaidd De-ddwyreiniol",
-    "De Koreaidd/De Coreaidd",
-    "Sbaenaidd",
-    "Sri Lancaidd",
-    "Swedaidd",
-    "Swisaidd",
-    "Taiwanaidd",
-    "Tamil",
-    "Tamil Eelam",
-    "Thai",
-    "Twrcaidd/Tyrcaidd",
-    "Cypraidd Twrcaidd/Cypraidd Tyrcaidd",
-    "Ugandaidd/Wgandaidd",
-    "Wcreinaidd/Ukrainaidd",
-    "Fietnameaidd/Vietnamaidd",
-    "Cymreig",
-    "Gorllewin Ewropeaidd",
-    "Gwyn Affricanaidd",
-    "Gwyn Prydeinig",
-    "Gwyn Caribïaidd",
-    "Gwyn Seisnig",
-    "Gwyn o Ogledd Iwerddon",
-    "Gwyn Albanaidd",
-    "Gwyn Cymreig",
-    "Yemenïaidd",
-    "Swydd Efrog",
-    "Simbabweaidd/Zimbabweaidd"
+    {
+        "cy": "Affganaidd/Afghanaidd"
+    },
+    {
+        "cy": "Affricanaidd"
+    },
+    {
+        "cy": "Affricanaidd Americanaidd"
+    },
+    {
+        "cy": "Affricanaidd Asiaidd"
+    },
+    {
+        "cy": "Affricanaidd Caribïaidd"
+    },
+    {
+        "cy": "Albaniaidd"
+    },
+    {
+        "cy": "Algeraidd"
+    },
+    {
+        "cy": "Americanaidd"
+    },
+    {
+        "cy": "Eingl-Indiaidd"
+    },
+    {
+        "cy": "Eingl-Wyddelig"
+    },
+    {
+        "cy": "Eingl-Eidalaidd"
+    },
+    {
+        "cy": "Eingl-Sacsonaidd"
+    },
+    {
+        "cy": "Arabaidd"
+    },
+    {
+        "cy": "Archentaidd"
+    },
+    {
+        "cy": "Armenaidd"
+    },
+    {
+        "cy": "Asiaidd"
+    },
+    {
+        "cy": "Asiaidd Prydeinig"
+    },
+    {
+        "cy": "Asiaidd Seisnig"
+    },
+    {
+        "cy": "Asiaidd o Ogledd Iwerddon"
+    },
+    {
+        "cy": "Asiaidd Albanaidd"
+    },
+    {
+        "cy": "Asiaidd Cymreig"
+    },
+    {
+        "cy": "Asyriaidd"
+    },
+    {
+        "cy": "Awstralaidd"
+    },
+    {
+        "cy": "Awstriaidd"
+    },
+    {
+        "cy": "Baltig"
+    },
+    {
+        "cy": "Bangladeshaidd"
+    },
+    {
+        "cy": "Belarwsiaidd"
+    },
+    {
+        "cy": "Belgaidd"
+    },
+    {
+        "cy": "Berberaidd"
+    },
+    {
+        "cy": "Du Affricanaidd"
+    },
+    {
+        "cy": "Du Prydeinig"
+    },
+    {
+        "cy": "Du Caribïaidd"
+    },
+    {
+        "cy": "Du Seisnig"
+    },
+    {
+        "cy": "Du o Ogledd Iwerddon"
+    },
+    {
+        "cy": "Du Albanaidd"
+    },
+    {
+        "cy": "Du Cymreig"
+    },
+    {
+        "cy": "Bosniaidd"
+    },
+    {
+        "cy": "Brasilaidd"
+    },
+    {
+        "cy": "Prydeinig"
+    },
+    {
+        "cy": "Prydeinig Indiaidd"
+    },
+    {
+        "cy": "Prydeinig Pacistanaidd"
+    },
+    {
+        "cy": "Bwlgaraidd"
+    },
+    {
+        "cy": "Byrmanaidd neu Myanma/Burmanaidd neu Myanma"
+    },
+    {
+        "cy": "Cambodiaidd"
+    },
+    {
+        "cy": "Canadaidd"
+    },
+    {
+        "cy": "Caribïaidd"
+    },
+    {
+        "cy": "Celtaidd"
+    },
+    {
+        "cy": "Canol Ewropeaidd"
+    },
+    {
+        "cy": "Chileaidd/Tsileaidd"
+    },
+    {
+        "cy": "Tsieineaidd/Chineaidd"
+    },
+    {
+        "cy": "Colombiaidd"
+    },
+    {
+        "cy": "Congolaidd"
+    },
+    {
+        "cy": "Cernywaidd"
+    },
+    {
+        "cy": "Croataidd"
+    },
+    {
+        "cy": "Cypraidd"
+    },
+    {
+        "cy": "Tsiecaidd"
+    },
+    {
+        "cy": "Danaidd"
+    },
+    {
+        "cy": "Iseldiraidd"
+    },
+    {
+        "cy": "Dwyrain Affricanaidd"
+    },
+    {
+        "cy": "Dwyrain Ewropeaidd"
+    },
+    {
+        "cy": "Eelam Tamil"
+    },
+    {
+        "cy": "Eritreaidd"
+    },
+    {
+        "cy": "Ethiopaidd"
+    },
+    {
+        "cy": "Eifftaidd"
+    },
+    {
+        "cy": "Seisnig"
+    },
+    {
+        "cy": "Estonaidd"
+    },
+    {
+        "cy": "Ewrasiaidd/Eurasiaidd"
+    },
+    {
+        "cy": "Ewropeaidd"
+    },
+    {
+        "cy": "Ffijïaidd"
+    },
+    {
+        "cy": "Ffilipinaidd"
+    },
+    {
+        "cy": "Ffinnaidd"
+    },
+    {
+        "cy": "Ffrengig"
+    },
+    {
+        "cy": "Georgaidd"
+    },
+    {
+        "cy": "Almaenaidd"
+    },
+    {
+        "cy": "Ghanaidd"
+    },
+    {
+        "cy": "Goaidd"
+    },
+    {
+        "cy": "Groegaidd"
+    },
+    {
+        "cy": "Groegaidd Cypraidd/Cypraidd Groegaidd"
+    },
+    {
+        "cy": "Gurkha/Gyrca"
+    },
+    {
+        "cy": "Gaianaidd/Guyanaidd"
+    },
+    {
+        "cy": "Sipsi"
+    },
+    {
+        "cy": "Helenaidd"
+    },
+    {
+        "cy": "Sbaenig/Hisbaenaidd"
+    },
+    {
+        "cy": "Hwngaraidd"
+    },
+    {
+        "cy": "Islandaidd"
+    },
+    {
+        "cy": "Indiaidd"
+    },
+    {
+        "cy": "Indonesaidd"
+    },
+    {
+        "cy": "Iranaidd"
+    },
+    {
+        "cy": "Iracaidd"
+    },
+    {
+        "cy": "Gwyddelig"
+    },
+    {
+        "cy": "Teithiwr Gwyddelig"
+    },
+    {
+        "cy": "Israelaidd"
+    },
+    {
+        "cy": "Eidalaidd"
+    },
+    {
+        "cy": "Jamaicaidd"
+    },
+    {
+        "cy": "Japaneaidd/Siapaneaidd"
+    },
+    {
+        "cy": "Iddewig"
+    },
+    {
+        "cy": "Kashmiraidd/Cashmiraidd"
+    },
+    {
+        "cy": "Kazakh"
+    },
+    {
+        "cy": "Kenyaidd/Cenyaidd"
+    },
+    {
+        "cy": "Koreaidd/Coreaidd"
+    },
+    {
+        "cy": "Kosofaidd/Cosofaidd"
+    },
+    {
+        "cy": "Cwrdaidd Kurdaidd/Kwrdaidd"
+    },
+    {
+        "cy": "Lladin Americanaidd"
+    },
+    {
+        "cy": "Latino"
+    },
+    {
+        "cy": "Latfiaidd"
+    },
+    {
+        "cy": "Libanaidd/Lebanaidd"
+    },
+    {
+        "cy": "Lithwanaidd"
+    },
+    {
+        "cy": "Macedonaidd"
+    },
+    {
+        "cy": "Malayaidd"
+    },
+    {
+        "cy": "Malaysiaidd"
+    },
+    {
+        "cy": "Maltaidd"
+    },
+    {
+        "cy": "Manawaidd"
+    },
+    {
+        "cy": "Mawrisaidd/Mauritaidd"
+    },
+    {
+        "cy": "Mediteranaidd"
+    },
+    {
+        "cy": "Mecsicanaidd/Mexicanaidd"
+    },
+    {
+        "cy": "O'r Dwyrain Canol"
+    },
+    {
+        "cy": "Mongolaidd"
+    },
+    {
+        "cy": "Morocaidd"
+    },
+    {
+        "cy": "Nepalaidd"
+    },
+    {
+        "cy": "O Seland Newydd"
+    },
+    {
+        "cy": "Nigeriaidd (Nigeria)"
+    },
+    {
+        "cy": "Nigeraidd (Niger)"
+    },
+    {
+        "cy": "Nordig"
+    },
+    {
+        "cy": "Gogledd Affricanaidd"
+    },
+    {
+        "cy": "Gogledd Americanaidd"
+    },
+    {
+        "cy": "Gogledd Ewropeaidd"
+    },
+    {
+        "cy": "Gwyddelig Gogledd Iwerddon"
+    },
+    {
+        "cy": "Norwyaidd"
+    },
+    {
+        "cy": "Pacistanaidd"
+    },
+    {
+        "cy": "Persiaidd"
+    },
+    {
+        "cy": "Ffilipinaidd"
+    },
+    {
+        "cy": "Pwylaidd"
+    },
+    {
+        "cy": "Portiwgeaidd"
+    },
+    {
+        "cy": "Pwnjabaidd/Punjabaidd"
+    },
+    {
+        "cy": "Roma"
+    },
+    {
+        "cy": "Rwmanaidd/Romanaidd"
+    },
+    {
+        "cy": "Rwsiaidd"
+    },
+    {
+        "cy": "São Tomeaidd"
+    },
+    {
+        "cy": "Sgandinafaidd"
+    },
+    {
+        "cy": "Albanaidd"
+    },
+    {
+        "cy": "Serbaidd"
+    },
+    {
+        "cy": "Dyn Sioe"
+    },
+    {
+        "cy": "Person Sioe"
+    },
+    {
+        "cy": "Menyw Sioe"
+    },
+    {
+        "cy": "Sicaidd/Sikhaidd"
+    },
+    {
+        "cy": "Sinhalesaidd"
+    },
+    {
+        "cy": "Slafig"
+    },
+    {
+        "cy": "Slofacaidd"
+    },
+    {
+        "cy": "Slofenaidd"
+    },
+    {
+        "cy": "Somali"
+    },
+    {
+        "cy": "Somalilandaidd"
+    },
+    {
+        "cy": "De Affricanaidd"
+    },
+    {
+        "cy": "De Americanaidd"
+    },
+    {
+        "cy": "Asiaidd De-ddwyreiniol"
+    },
+    {
+        "cy": "De Koreaidd/De Coreaidd"
+    },
+    {
+        "cy": "Sbaenaidd"
+    },
+    {
+        "cy": "Sri Lancaidd"
+    },
+    {
+        "cy": "Swedaidd"
+    },
+    {
+        "cy": "Swisaidd"
+    },
+    {
+        "cy": "Taiwanaidd"
+    },
+    {
+        "cy": "Tamil"
+    },
+    {
+        "cy": "Tamil Eelam"
+    },
+    {
+        "cy": "Thai"
+    },
+    {
+        "cy": "Twrcaidd/Tyrcaidd"
+    },
+    {
+        "cy": "Cypraidd Twrcaidd/Cypraidd Tyrcaidd"
+    },
+    {
+        "cy": "Ugandaidd/Wgandaidd"
+    },
+    {
+        "cy": "Wcreinaidd/Ukrainaidd"
+    },
+    {
+        "cy": "Fietnameaidd/Vietnamaidd"
+    },
+    {
+        "cy": "Cymreig"
+    },
+    {
+        "cy": "Gorllewin Ewropeaidd"
+    },
+    {
+        "cy": "Gwyn Affricanaidd"
+    },
+    {
+        "cy": "Gwyn Prydeinig"
+    },
+    {
+        "cy": "Gwyn Caribïaidd"
+    },
+    {
+        "cy": "Gwyn Seisnig"
+    },
+    {
+        "cy": "Gwyn o Ogledd Iwerddon"
+    },
+    {
+        "cy": "Gwyn Albanaidd"
+    },
+    {
+        "cy": "Gwyn Cymreig"
+    },
+    {
+        "cy": "Yemenïaidd"
+    },
+    {
+        "cy": "Swydd Efrog"
+    },
+    {
+        "cy": "Simbabweaidd/Zimbabweaidd"
+    }
 ]

--- a/data/gb/cy/languages.json
+++ b/data/gb/cy/languages.json
@@ -1,175 +1,521 @@
 [
-    "Abkhazeg",
-    "Afar",
-    "Afrikaans",
-    "Albanieg",
-    "Amhareg",
-    "Arabeg",
-    "Aragoneg",
-    "Armeneg",
-    "Assameg",
-    "Aymara",
-    "Azerbaijaneg",
-    "Bambara",
-    "Bashkir",
-    "Basgeg",
-    "Belarwseg",
-    "Bengaleg neu Bangla",
-    "Ieithoedd Bihari",
-    "Bislama",
-    "Bosnieg",
-    "Llydaweg/Brezhoneg",
-    "Iaith Arwyddion Prydain",
-    "Bwlgareg",
-    "Burmaneg/Byrmaneg",
-    "Cantoneg",
-    "Castileg",
-    "Catalaneg",
-    "Chechen",
-    "Chewa",
-    "Chichewa",
-    "Chineeg/Tsieineeg",
-    "Chuvash",
-    "Cernyweg/Kernowek",
-    "Crïeg",
-    "Croateg",
-    "Cymraeg",
-    "Tsieceg",
-    "Daneg",
-    "Dari",
-    "Dhivehi",
-    "Iseldireg",
-    "Dzongkha",
-    "Saesneg",
-    "Estoneg",
-    "Ewe",
-    "Ffaröeg",
-    "Ffijïeg",
-    "Ffilipineg",
-    "Ffinneg",
-    "Fflemineg",
-    "Ffrangeg",
-    "Fulah",
-    "Gaeleg/Gaelige",
-    "Ganda",
-    "Georgeg",
-    "Almaeneg",
-    "Gikuyu",
-    "Groeg",
-    "Glasynyseg",
-    "Guarani/Gwarani",
-    "Gujarati/Gwjarati",
-    "Haiteg",
-    "Creoliaith Haiti",
-    "Hausa/Hawsa",
-    "Hebraeg",
-    "Herero",
-    "Hindi",
-    "Hwngareg",
-    "Islandeg",
-    "Igbo",
-    "Indoneseg",
-    "Gwyddeleg",
-    "Eidaleg",
-    "Japaneeg/Siapaneeg",
-    "Javaneg/Jafaneg",
-    "Kannada/Canareg",
-    "Kanuri",
-    "Kashmireg/Cashmireg",
-    "Kazakh",
-    "Kikuyu",
-    "Kinyarwanda",
-    "Komi",
-    "Korëeg/Corëeg",
-    "Kurdeg/Cwrdeg",
-    "Kwanyama",
-    "Kyrgyz",
-    "Laoseg",
-    "Latfieg",
-    "Letzeburgesch",
-    "Lingala",
-    "Lithwaneg",
-    "Lwcsembwrgeg",
-    "Macedoneg",
-    "Malagasi",
-    "Maleieg",
-    "Malaialam",
-    "Iaith Maldives",
-    "Malteg",
-    "Mandarin",
-    "Manaweg",
-    "Maori",
-    "Marati",
-    "Mirpuri",
-    "Moldofeg",
-    "Mongoleg",
-    "Navajo",
-    "Nepaleg",
-    "Ndebele Gogleddol",
-    "Norwyeg",
-    "Norwyeg (Bokmål)",
-    "Norwyedg (Nynorsk)",
-    "Nyanja",
-    "Oriya",
-    "Oromo",
-    "Pwnjabeg",
-    "Pashto",
-    "Perseg neu Ffarsi",
-    "Pwyleg",
-    "Portiwgaleg",
-    "Punjabeg",
-    "Pushto",
-    "Quechua",
-    "Romaneg/Rwmaneg",
-    "Romansh",
-    "Rundi",
-    "Rwseg",
-    "Samöeg",
-    "Sango",
-    "Gaeleg yr Alban/Gàidhlig",
-    "Serbeg",
-    "Shona",
-    "Sindhi",
-    "Sinhala",
-    "Slofaceg",
-    "Slofeneg",
-    "Somalieg",
-    "Sotho Deheuol",
-    "Ndebele Deheuol",
-    "Sbaeneg",
-    "Sundaneg/Swndaneg",
-    "Swahili",
-    "Swati",
-    "Swedeg",
-    "Sylheti",
-    "Tagalog",
-    "Tahitïeg",
-    "Tajik",
-    "Tamil",
-    "Tatar",
-    "Telugu/Telwgw",
-    "Thai",
-    "Tibeteg",
-    "Tigrinya",
-    "Tonga (Ynysoedd Tonga)",
-    "Tsonga",
-    "Tswana",
-    "Twrceg/Tyrceg",
-    "Turkmeneg/Tyrcmeneg",
-    "Twi",
-    "Uighur",
-    "Ukreineg/Wcreineg",
-    "Urdu/Wrdw",
-    "Uyghur",
-    "Uzbek",
-    "Venda",
-    "Vietnameg/Fietnameg",
-    "Walwneg",
-    "Cymraeg",
-    "Woloff",
-    "Xhosa",
-    "Yiddeg/Iddew-Almaeneg",
-    "Yoruba/Iorwba",
-    "Zhuang",
-    "Zulu/Zwlw"
+    {
+        "cy": "Abkhazeg"
+    },
+    {
+        "cy": "Afar"
+    },
+    {
+        "cy": "Afrikaans"
+    },
+    {
+        "cy": "Albanieg"
+    },
+    {
+        "cy": "Amhareg"
+    },
+    {
+        "cy": "Arabeg"
+    },
+    {
+        "cy": "Aragoneg"
+    },
+    {
+        "cy": "Armeneg"
+    },
+    {
+        "cy": "Assameg"
+    },
+    {
+        "cy": "Aymara"
+    },
+    {
+        "cy": "Azerbaijaneg"
+    },
+    {
+        "cy": "Bambara"
+    },
+    {
+        "cy": "Bashkir"
+    },
+    {
+        "cy": "Basgeg"
+    },
+    {
+        "cy": "Belarwseg"
+    },
+    {
+        "cy": "Bengaleg neu Bangla"
+    },
+    {
+        "cy": "Ieithoedd Bihari"
+    },
+    {
+        "cy": "Bislama"
+    },
+    {
+        "cy": "Bosnieg"
+    },
+    {
+        "cy": "Llydaweg/Brezhoneg"
+    },
+    {
+        "cy": "Iaith Arwyddion Prydain"
+    },
+    {
+        "cy": "Bwlgareg"
+    },
+    {
+        "cy": "Burmaneg/Byrmaneg"
+    },
+    {
+        "cy": "Cantoneg"
+    },
+    {
+        "cy": "Castileg"
+    },
+    {
+        "cy": "Catalaneg"
+    },
+    {
+        "cy": "Chechen"
+    },
+    {
+        "cy": "Chewa"
+    },
+    {
+        "cy": "Chichewa"
+    },
+    {
+        "cy": "Chineeg/Tsieineeg"
+    },
+    {
+        "cy": "Chuvash"
+    },
+    {
+        "cy": "Cernyweg/Kernowek"
+    },
+    {
+        "cy": "Crïeg"
+    },
+    {
+        "cy": "Croateg"
+    },
+    {
+        "cy": "Cymraeg"
+    },
+    {
+        "cy": "Tsieceg"
+    },
+    {
+        "cy": "Daneg"
+    },
+    {
+        "cy": "Dari"
+    },
+    {
+        "cy": "Dhivehi"
+    },
+    {
+        "cy": "Iseldireg"
+    },
+    {
+        "cy": "Dzongkha"
+    },
+    {
+        "cy": "Saesneg"
+    },
+    {
+        "cy": "Estoneg"
+    },
+    {
+        "cy": "Ewe"
+    },
+    {
+        "cy": "Ffaröeg"
+    },
+    {
+        "cy": "Ffijïeg"
+    },
+    {
+        "cy": "Ffilipineg"
+    },
+    {
+        "cy": "Ffinneg"
+    },
+    {
+        "cy": "Fflemineg"
+    },
+    {
+        "cy": "Ffrangeg"
+    },
+    {
+        "cy": "Fulah"
+    },
+    {
+        "cy": "Gaeleg/Gaelige"
+    },
+    {
+        "cy": "Ganda"
+    },
+    {
+        "cy": "Georgeg"
+    },
+    {
+        "cy": "Almaeneg"
+    },
+    {
+        "cy": "Gikuyu"
+    },
+    {
+        "cy": "Groeg"
+    },
+    {
+        "cy": "Glasynyseg"
+    },
+    {
+        "cy": "Guarani/Gwarani"
+    },
+    {
+        "cy": "Gujarati/Gwjarati"
+    },
+    {
+        "cy": "Haiteg"
+    },
+    {
+        "cy": "Creoliaith Haiti"
+    },
+    {
+        "cy": "Hausa/Hawsa"
+    },
+    {
+        "cy": "Hebraeg"
+    },
+    {
+        "cy": "Herero"
+    },
+    {
+        "cy": "Hindi"
+    },
+    {
+        "cy": "Hwngareg"
+    },
+    {
+        "cy": "Islandeg"
+    },
+    {
+        "cy": "Igbo"
+    },
+    {
+        "cy": "Indoneseg"
+    },
+    {
+        "cy": "Gwyddeleg"
+    },
+    {
+        "cy": "Eidaleg"
+    },
+    {
+        "cy": "Japaneeg/Siapaneeg"
+    },
+    {
+        "cy": "Javaneg/Jafaneg"
+    },
+    {
+        "cy": "Kannada/Canareg"
+    },
+    {
+        "cy": "Kanuri"
+    },
+    {
+        "cy": "Kashmireg/Cashmireg"
+    },
+    {
+        "cy": "Kazakh"
+    },
+    {
+        "cy": "Kikuyu"
+    },
+    {
+        "cy": "Kinyarwanda"
+    },
+    {
+        "cy": "Komi"
+    },
+    {
+        "cy": "Korëeg/Corëeg"
+    },
+    {
+        "cy": "Kurdeg/Cwrdeg"
+    },
+    {
+        "cy": "Kwanyama"
+    },
+    {
+        "cy": "Kyrgyz"
+    },
+    {
+        "cy": "Laoseg"
+    },
+    {
+        "cy": "Latfieg"
+    },
+    {
+        "cy": "Letzeburgesch"
+    },
+    {
+        "cy": "Lingala"
+    },
+    {
+        "cy": "Lithwaneg"
+    },
+    {
+        "cy": "Lwcsembwrgeg"
+    },
+    {
+        "cy": "Macedoneg"
+    },
+    {
+        "cy": "Malagasi"
+    },
+    {
+        "cy": "Maleieg"
+    },
+    {
+        "cy": "Malaialam"
+    },
+    {
+        "cy": "Iaith Maldives"
+    },
+    {
+        "cy": "Malteg"
+    },
+    {
+        "cy": "Mandarin"
+    },
+    {
+        "cy": "Manaweg"
+    },
+    {
+        "cy": "Maori"
+    },
+    {
+        "cy": "Marati"
+    },
+    {
+        "cy": "Mirpuri"
+    },
+    {
+        "cy": "Moldofeg"
+    },
+    {
+        "cy": "Mongoleg"
+    },
+    {
+        "cy": "Navajo"
+    },
+    {
+        "cy": "Nepaleg"
+    },
+    {
+        "cy": "Ndebele Gogleddol"
+    },
+    {
+        "cy": "Norwyeg"
+    },
+    {
+        "cy": "Norwyeg (Bokmål)"
+    },
+    {
+        "cy": "Norwyedg (Nynorsk)"
+    },
+    {
+        "cy": "Nyanja"
+    },
+    {
+        "cy": "Oriya"
+    },
+    {
+        "cy": "Oromo"
+    },
+    {
+        "cy": "Pwnjabeg"
+    },
+    {
+        "cy": "Pashto"
+    },
+    {
+        "cy": "Perseg neu Ffarsi"
+    },
+    {
+        "cy": "Pwyleg"
+    },
+    {
+        "cy": "Portiwgaleg"
+    },
+    {
+        "cy": "Punjabeg"
+    },
+    {
+        "cy": "Pushto"
+    },
+    {
+        "cy": "Quechua"
+    },
+    {
+        "cy": "Romaneg/Rwmaneg"
+    },
+    {
+        "cy": "Romansh"
+    },
+    {
+        "cy": "Rundi"
+    },
+    {
+        "cy": "Rwseg"
+    },
+    {
+        "cy": "Samöeg"
+    },
+    {
+        "cy": "Sango"
+    },
+    {
+        "cy": "Gaeleg yr Alban/Gàidhlig"
+    },
+    {
+        "cy": "Serbeg"
+    },
+    {
+        "cy": "Shona"
+    },
+    {
+        "cy": "Sindhi"
+    },
+    {
+        "cy": "Sinhala"
+    },
+    {
+        "cy": "Slofaceg"
+    },
+    {
+        "cy": "Slofeneg"
+    },
+    {
+        "cy": "Somalieg"
+    },
+    {
+        "cy": "Sotho Deheuol"
+    },
+    {
+        "cy": "Ndebele Deheuol"
+    },
+    {
+        "cy": "Sbaeneg"
+    },
+    {
+        "cy": "Sundaneg/Swndaneg"
+    },
+    {
+        "cy": "Swahili"
+    },
+    {
+        "cy": "Swati"
+    },
+    {
+        "cy": "Swedeg"
+    },
+    {
+        "cy": "Sylheti"
+    },
+    {
+        "cy": "Tagalog"
+    },
+    {
+        "cy": "Tahitïeg"
+    },
+    {
+        "cy": "Tajik"
+    },
+    {
+        "cy": "Tamil"
+    },
+    {
+        "cy": "Tatar"
+    },
+    {
+        "cy": "Telugu/Telwgw"
+    },
+    {
+        "cy": "Thai"
+    },
+    {
+        "cy": "Tibeteg"
+    },
+    {
+        "cy": "Tigrinya"
+    },
+    {
+        "cy": "Tonga (Ynysoedd Tonga)"
+    },
+    {
+        "cy": "Tsonga"
+    },
+    {
+        "cy": "Tswana"
+    },
+    {
+        "cy": "Twrceg/Tyrceg"
+    },
+    {
+        "cy": "Turkmeneg/Tyrcmeneg"
+    },
+    {
+        "cy": "Twi"
+    },
+    {
+        "cy": "Uighur"
+    },
+    {
+        "cy": "Ukreineg/Wcreineg"
+    },
+    {
+        "cy": "Urdu/Wrdw"
+    },
+    {
+        "cy": "Uyghur"
+    },
+    {
+        "cy": "Uzbek"
+    },
+    {
+        "cy": "Venda"
+    },
+    {
+        "cy": "Vietnameg/Fietnameg"
+    },
+    {
+        "cy": "Walwneg"
+    },
+    {
+        "cy": "Cymraeg"
+    },
+    {
+        "cy": "Woloff"
+    },
+    {
+        "cy": "Xhosa"
+    },
+    {
+        "cy": "Yiddeg/Iddew-Almaeneg"
+    },
+    {
+        "cy": "Yoruba/Iorwba"
+    },
+    {
+        "cy": "Zhuang"
+    },
+    {
+        "cy": "Zulu/Zwlw"
+    }
 ]

--- a/data/gb/cy/national-identities.json
+++ b/data/gb/cy/national-identities.json
@@ -1,277 +1,827 @@
 [
-    "Afghaniad/Affganiad",
-    "Affricanwr/Affricanes",
-    "Un o Ynysoedd Åland",
-    "Albaniad",
-    "Algeriad",
-    "Americanwr/Americanes",
-    "Un o Ynysoedd America",
-    "Samoad Americanaidd",
-    "Andoriad",
-    "Angoliad",
-    "Anguilliad",
-    "Antigwad",
-    "Archentwr/Archentwraig/Un o'r Ariannin",
-    "Armeniad",
-    "Arubiad/Arwbiad",
-    "Asiad",
-    "Awstraliad",
-    "Awstriad",
-    "Azerbaijaniad",
-    "Bahamiad",
-    "Bahrainiad",
-    "Bangladeshiad",
-    "Barbadiad",
-    "Barbudiad",
-    "Un o St Barthélemy",
-    "Botswaniad",
-    "Belarwsiad",
-    "Belgiad",
-    "Beliziad",
-    "Beniniad",
-    "Bermudiad",
-    "Bhutaniad",
-    "Un o Guineau-Bissau",
-    "Bolifiad",
-    "Un o Bonaire",
-    "Un o Unol Daleithiau America",
-    "Sabiad",
-    "Bosniad",
-    "Brasiliad",
-    "Prydeiniwr/Prydeinwraig",
-    "Un o Brunei",
-    "Bwlgariad",
-    "Un o Burkina Faso",
-    "Burmaniad/Byrmaniad",
-    "Burundiad/Bwrwndiad",
-    "Cambodiad",
-    "Camerooniad",
-    "Canadiad",
-    "Un o'r Ynysoedd Dedwydd",
-    "Un o Cabo Verde",
-    "Un o Ynysoedd Cayman",
-    "Un o Ganolbarth Affrica/Un o Weriniaeth Canol Affrica",
-    "Chadiad",
-    "Un o Ynysoedd Chagos",
-    "Un o Ynysoedd y Sianel",
-    "Chilead/Tsilead",
-    "Chinead/Tsieinead",
-    "Un o Ynys y Nadolig",
-    "Un o Ynysoedd Cocos",
-    "Colombiad",
-    "Comoriad",
-    "Congoliad (Gweriniaeth Ddemocrataidd Congo)",
-    "Congoliad (Gweriniaeth Congo)",
-    "Un o Ynysoedd Cook",
-    "Cernywiad/Un o Gernyw",
-    "Un o Costa Rica",
-    "Croatiad",
-    "Ciwbaniad",
-    "Curaçaoiad",
-    "Cypriad",
-    "Tsieciad",
-    "Daniad",
-    "Djiboutiad",
-    "Dominiciad (Dominica)",
-    "Dominiciad (Gweriniaeth Dominica)",
-    "Iseldirwr/Iseldirwraig",
-    "Un o Ddwyrain Timor",
-    "Ecuadoriad/Ecwadoriad",
-    "Eifftiad",
-    "Un o'r Emiraethau Arabaidd Unedig",
-    "Sais/Saesnes",
-    "Un o Guinea Gyhydeddol",
-    "Eritread",
-    "Estoniad",
-    "Ethiopiad",
-    "Ewropead",
-    "Un o Ynysoedd Falkland (Malvinas)",
-    "Ffaroad",
-    "Ffijïad",
-    "Ffilipina",
-    "Ffilipino",
-    "Ffiniad",
-    "Ffrancwr/Ffrances",
-    "Un o Polynesia Ffrengig",
-    "Futuniad",
-    "Gaboniad",
-    "Gambiad",
-    "Georgiad",
-    "Almaenwr/Almaenes",
-    "Ghanaiad",
-    "Gibraltariad",
-    "Groegwr/Groeges",
-    "Cypriad Groegaidd",
-    "Un o Kalaallit Nunaat (Greenland)",
-    "Grenadiad",
-    "Guadeloupiad",
-    "Guamiad/Gwamiad",
-    "Guatemaliad/Gwatemaliad",
-    "Gaianiad",
-    "Un o Guinea (Guinea)",
-    "Un o Guinea (Guinea-Bissau)",
-    "Gyuaniad",
-    "Haitïad",
-    "Honduriad",
-    "Un o Hong Kong",
-    "Chinead Hong Kong/Tsieinead Hong Kong",
-    "Hwngariad",
-    "Un o Wlad yr Iâ",
-    "Un o Kiribati",
-    "Indiad",
-    "Indonesiad",
-    "Iraniad",
-    "Iraciad",
-    "Gwyddel/Gwyddeles",
-    "Israeliad",
-    "Eidalwr/Eidales",
-    "Un o'r Traeth Ifori",
-    "Jamaicad",
-    "Japanead/Siapanead",
-    "Un o Wlad yr Iorddonen",
-    "Kazakhstaniad",
-    "Kenyad/Ceniad",
-    "Kernewek",
-    "Kernouak",
-    "Kernowyon",
-    "Kernowek",
-    "Un o St Kitts",
-    "Koread/Coread",
-    "Kosoviad/Cosofiad",
-    "Kurdiad/Cwrdiad",
-    "Kuwaitiad/Coweitiad",
-    "Kyrgyzstaniad",
-    "Laosiad",
-    "Latfiad",
-    "Lebaniad/Libaniad",
-    "Lesothiad",
-    "Liberiad",
-    "Libiad",
-    "Liechtensteiniad",
-    "Lithwaniad",
-    "Luxembourgiad",
-    "Macaoiad",
-    "Macedoniad",
-    "Madagasgiad",
-    "Malawiad",
-    "Malaysiad",
-    "Maldiviad",
-    "Maliad",
-    "Melitiad",
-    "Manawiad",
-    "Maori",
-    "Un o Ynysoedd Marshall",
-    "Martiniquiad",
-    "Mauritaniad/Mawritaniad",
-    "Mauritiad/Mawritiad",
-    "Mexicanwr/Mecsicanwr/Mexicanes/Mecsicanes",
-    "Micronesiad",
-    "Miqueloniad",
-    "Moldofiad",
-    "Monaciad",
-    "Mongoliad",
-    "Montenegroad",
-    "Montserratiad",
-    "Morociad",
-    "Botswaniad",
-    "Mozambiquiad",
-    "Un o Myanmar (Burma)",
-    "Namibiad",
-    "Nauruad/Nawrŵad",
-    "Nepali",
-    "Un o Nevis",
-    "Un o Caledonia Newydd",
-    "Un o Seland Newydd",
-    "Nicaragwad",
-    "Nigeriad (Nigeria)",
-    "Nigeriad (Niger)",
-    "Un o Niue",
-    "Un o Vanuatu",
-    "Un o Ynys Norfolk",
-    "Un o Ogledd Korea/Un o Ogledd Corea",
-    "Gwyddel/Gwyddeles o Ogledd Iwerddon",
-    "Un o Ynysoedd Gogleddol Mariana",
-    "Norwyad",
-    "Omaniad",
-    "Pacistaniad",
-    "Palauiad",
-    "Palesteiniad",
-    "Panamaniad",
-    "Un o Papua Guinea Newydd",
-    "Paraguayad",
-    "Periwiad",
-    "Un o Ynysoedd Pitcairn",
-    "Pwyliad",
-    "Portiwgaliad",
-    "Puerto Riciad",
-    "Qatariad",
-    "Quisqueyad",
-    "Un o Réunion",
-    "Romaniad/Rwmaniad",
-    "Rwsiad",
-    "Rwandiad",
-    "Sahrawi",
-    "Un o St Helena",
-    "Un o Sint Maarten",
-    "Un o St Vincent",
-    "Un o Saint Martin",
-    "Un o St Pierre",
-    "Un o El Salvador",
-    "Un o San Marino",
-    "Samoad",
-    "Un o São Tomé a Príncipe",
-    "Un o Saudi Arabia/Un o Sawdi-Arabia",
-    "Albanwr/Albanes",
-    "Senegaliad",
-    "Serbiad",
-    "Un o Seychelles",
-    "Un o Sierra Leone",
-    "Singaporead",
-    "Slofaciad",
-    "Slofeniad",
-    "Un o Ynysoedd Solomon",
-    "Somaliad",
-    "Un o Dde Affrica",
-    "Un o Dde Georgia",
-    "Un o Dde Korea/Un o Dde Corea",
-    "Un o Ynysoedd Sandwich y De",
-    "Un o Dde Sudan",
-    "Sbaenwr/Sbaenes",
-    "Sri Lancad",
-    "Un o Saint Lucia",
-    "Un o St Lucia",
-    "Sudaniad/Swdaniad",
-    "Surinamead",
-    "Un o Svalbard a Jan Mayen",
-    "Swaziad/Un o Eswatini",
-    "Swediad",
-    "Swisiad",
-    "Syriad",
-    "Taiwaniad",
-    "Tajik",
-    "Tansanïad",
-    "Thai",
-    "Togoliad",
-    "Tokelauiad",
-    "Tongiad",
-    "Un o Trinidad a Tobago",
-    "Tunisiad/Tiwnisiad",
-    "Twrc/Tyrc",
-    "Cypriad Twrcaidd",
-    "Turkmenistaniad",
-    "Un o Ynysoedd Turks a Caicos",
-    "Tuvaluad",
-    "Ugandiad/Wgandiad",
-    "Ukrainiad/Wcraniad",
-    "Uruguayad/Wrwgwaiad",
-    "Uzbekiad/Wsbeciad",
-    "Venezueliad/Fenesweliad",
-    "Vietnamiad/Fietnamiad",
-    "Un o St Vincent a'r Grenadines",
-    "Un o Ynysoedd y Wyryf",
-    "Un o Wallis",
-    "Cymro/Cymraes",
-    "Yemeniad/Iemeniad",
-    "Zambiad/Sambiad",
-    "Zimbabwead/Simbabwead"
+    {
+        "cy": "Afghaniad/Affganiad"
+    },
+    {
+        "cy": "Affricanwr/Affricanes"
+    },
+    {
+        "cy": "Un o Ynysoedd Åland"
+    },
+    {
+        "cy": "Albaniad"
+    },
+    {
+        "cy": "Algeriad"
+    },
+    {
+        "cy": "Americanwr/Americanes"
+    },
+    {
+        "cy": "Un o Ynysoedd America"
+    },
+    {
+        "cy": "Samoad Americanaidd"
+    },
+    {
+        "cy": "Andoriad"
+    },
+    {
+        "cy": "Angoliad"
+    },
+    {
+        "cy": "Anguilliad"
+    },
+    {
+        "cy": "Antigwad"
+    },
+    {
+        "cy": "Archentwr/Archentwraig/Un o'r Ariannin"
+    },
+    {
+        "cy": "Armeniad"
+    },
+    {
+        "cy": "Arubiad/Arwbiad"
+    },
+    {
+        "cy": "Asiad"
+    },
+    {
+        "cy": "Awstraliad"
+    },
+    {
+        "cy": "Awstriad"
+    },
+    {
+        "cy": "Azerbaijaniad"
+    },
+    {
+        "cy": "Bahamiad"
+    },
+    {
+        "cy": "Bahrainiad"
+    },
+    {
+        "cy": "Bangladeshiad"
+    },
+    {
+        "cy": "Barbadiad"
+    },
+    {
+        "cy": "Barbudiad"
+    },
+    {
+        "cy": "Un o St Barthélemy"
+    },
+    {
+        "cy": "Botswaniad"
+    },
+    {
+        "cy": "Belarwsiad"
+    },
+    {
+        "cy": "Belgiad"
+    },
+    {
+        "cy": "Beliziad"
+    },
+    {
+        "cy": "Beniniad"
+    },
+    {
+        "cy": "Bermudiad"
+    },
+    {
+        "cy": "Bhutaniad"
+    },
+    {
+        "cy": "Un o Guineau-Bissau"
+    },
+    {
+        "cy": "Bolifiad"
+    },
+    {
+        "cy": "Un o Bonaire"
+    },
+    {
+        "cy": "Un o Unol Daleithiau America"
+    },
+    {
+        "cy": "Sabiad"
+    },
+    {
+        "cy": "Bosniad"
+    },
+    {
+        "cy": "Brasiliad"
+    },
+    {
+        "cy": "Prydeiniwr/Prydeinwraig"
+    },
+    {
+        "cy": "Un o Brunei"
+    },
+    {
+        "cy": "Bwlgariad"
+    },
+    {
+        "cy": "Un o Burkina Faso"
+    },
+    {
+        "cy": "Burmaniad/Byrmaniad"
+    },
+    {
+        "cy": "Burundiad/Bwrwndiad"
+    },
+    {
+        "cy": "Cambodiad"
+    },
+    {
+        "cy": "Camerooniad"
+    },
+    {
+        "cy": "Canadiad"
+    },
+    {
+        "cy": "Un o'r Ynysoedd Dedwydd"
+    },
+    {
+        "cy": "Un o Cabo Verde"
+    },
+    {
+        "cy": "Un o Ynysoedd Cayman"
+    },
+    {
+        "cy": "Un o Ganolbarth Affrica/Un o Weriniaeth Canol Affrica"
+    },
+    {
+        "cy": "Chadiad"
+    },
+    {
+        "cy": "Un o Ynysoedd Chagos"
+    },
+    {
+        "cy": "Un o Ynysoedd y Sianel"
+    },
+    {
+        "cy": "Chilead/Tsilead"
+    },
+    {
+        "cy": "Chinead/Tsieinead"
+    },
+    {
+        "cy": "Un o Ynys y Nadolig"
+    },
+    {
+        "cy": "Un o Ynysoedd Cocos"
+    },
+    {
+        "cy": "Colombiad"
+    },
+    {
+        "cy": "Comoriad"
+    },
+    {
+        "cy": "Congoliad (Gweriniaeth Ddemocrataidd Congo)"
+    },
+    {
+        "cy": "Congoliad (Gweriniaeth Congo)"
+    },
+    {
+        "cy": "Un o Ynysoedd Cook"
+    },
+    {
+        "cy": "Cernywiad/Un o Gernyw"
+    },
+    {
+        "cy": "Un o Costa Rica"
+    },
+    {
+        "cy": "Croatiad"
+    },
+    {
+        "cy": "Ciwbaniad"
+    },
+    {
+        "cy": "Curaçaoiad"
+    },
+    {
+        "cy": "Cypriad"
+    },
+    {
+        "cy": "Tsieciad"
+    },
+    {
+        "cy": "Daniad"
+    },
+    {
+        "cy": "Djiboutiad"
+    },
+    {
+        "cy": "Dominiciad (Dominica)"
+    },
+    {
+        "cy": "Dominiciad (Gweriniaeth Dominica)"
+    },
+    {
+        "cy": "Iseldirwr/Iseldirwraig"
+    },
+    {
+        "cy": "Un o Ddwyrain Timor"
+    },
+    {
+        "cy": "Ecuadoriad/Ecwadoriad"
+    },
+    {
+        "cy": "Eifftiad"
+    },
+    {
+        "cy": "Un o'r Emiraethau Arabaidd Unedig"
+    },
+    {
+        "cy": "Sais/Saesnes"
+    },
+    {
+        "cy": "Un o Guinea Gyhydeddol"
+    },
+    {
+        "cy": "Eritread"
+    },
+    {
+        "cy": "Estoniad"
+    },
+    {
+        "cy": "Ethiopiad"
+    },
+    {
+        "cy": "Ewropead"
+    },
+    {
+        "cy": "Un o Ynysoedd Falkland (Malvinas)"
+    },
+    {
+        "cy": "Ffaroad"
+    },
+    {
+        "cy": "Ffijïad"
+    },
+    {
+        "cy": "Ffilipina"
+    },
+    {
+        "cy": "Ffilipino"
+    },
+    {
+        "cy": "Ffiniad"
+    },
+    {
+        "cy": "Ffrancwr/Ffrances"
+    },
+    {
+        "cy": "Un o Polynesia Ffrengig"
+    },
+    {
+        "cy": "Futuniad"
+    },
+    {
+        "cy": "Gaboniad"
+    },
+    {
+        "cy": "Gambiad"
+    },
+    {
+        "cy": "Georgiad"
+    },
+    {
+        "cy": "Almaenwr/Almaenes"
+    },
+    {
+        "cy": "Ghanaiad"
+    },
+    {
+        "cy": "Gibraltariad"
+    },
+    {
+        "cy": "Groegwr/Groeges"
+    },
+    {
+        "cy": "Cypriad Groegaidd"
+    },
+    {
+        "cy": "Un o Kalaallit Nunaat (Greenland)"
+    },
+    {
+        "cy": "Grenadiad"
+    },
+    {
+        "cy": "Guadeloupiad"
+    },
+    {
+        "cy": "Guamiad/Gwamiad"
+    },
+    {
+        "cy": "Guatemaliad/Gwatemaliad"
+    },
+    {
+        "cy": "Gaianiad"
+    },
+    {
+        "cy": "Un o Guinea (Guinea)"
+    },
+    {
+        "cy": "Un o Guinea (Guinea-Bissau)"
+    },
+    {
+        "cy": "Gyuaniad"
+    },
+    {
+        "cy": "Haitïad"
+    },
+    {
+        "cy": "Honduriad"
+    },
+    {
+        "cy": "Un o Hong Kong"
+    },
+    {
+        "cy": "Chinead Hong Kong/Tsieinead Hong Kong"
+    },
+    {
+        "cy": "Hwngariad"
+    },
+    {
+        "cy": "Un o Wlad yr Iâ"
+    },
+    {
+        "cy": "Un o Kiribati"
+    },
+    {
+        "cy": "Indiad"
+    },
+    {
+        "cy": "Indonesiad"
+    },
+    {
+        "cy": "Iraniad"
+    },
+    {
+        "cy": "Iraciad"
+    },
+    {
+        "cy": "Gwyddel/Gwyddeles"
+    },
+    {
+        "cy": "Israeliad"
+    },
+    {
+        "cy": "Eidalwr/Eidales"
+    },
+    {
+        "cy": "Un o'r Traeth Ifori"
+    },
+    {
+        "cy": "Jamaicad"
+    },
+    {
+        "cy": "Japanead/Siapanead"
+    },
+    {
+        "cy": "Un o Wlad yr Iorddonen"
+    },
+    {
+        "cy": "Kazakhstaniad"
+    },
+    {
+        "cy": "Kenyad/Ceniad"
+    },
+    {
+        "cy": "Kernewek"
+    },
+    {
+        "cy": "Kernouak"
+    },
+    {
+        "cy": "Kernowyon"
+    },
+    {
+        "cy": "Kernowek"
+    },
+    {
+        "cy": "Un o St Kitts"
+    },
+    {
+        "cy": "Koread/Coread"
+    },
+    {
+        "cy": "Kosoviad/Cosofiad"
+    },
+    {
+        "cy": "Kurdiad/Cwrdiad"
+    },
+    {
+        "cy": "Kuwaitiad/Coweitiad"
+    },
+    {
+        "cy": "Kyrgyzstaniad"
+    },
+    {
+        "cy": "Laosiad"
+    },
+    {
+        "cy": "Latfiad"
+    },
+    {
+        "cy": "Lebaniad/Libaniad"
+    },
+    {
+        "cy": "Lesothiad"
+    },
+    {
+        "cy": "Liberiad"
+    },
+    {
+        "cy": "Libiad"
+    },
+    {
+        "cy": "Liechtensteiniad"
+    },
+    {
+        "cy": "Lithwaniad"
+    },
+    {
+        "cy": "Luxembourgiad"
+    },
+    {
+        "cy": "Macaoiad"
+    },
+    {
+        "cy": "Macedoniad"
+    },
+    {
+        "cy": "Madagasgiad"
+    },
+    {
+        "cy": "Malawiad"
+    },
+    {
+        "cy": "Malaysiad"
+    },
+    {
+        "cy": "Maldiviad"
+    },
+    {
+        "cy": "Maliad"
+    },
+    {
+        "cy": "Melitiad"
+    },
+    {
+        "cy": "Manawiad"
+    },
+    {
+        "cy": "Maori"
+    },
+    {
+        "cy": "Un o Ynysoedd Marshall"
+    },
+    {
+        "cy": "Martiniquiad"
+    },
+    {
+        "cy": "Mauritaniad/Mawritaniad"
+    },
+    {
+        "cy": "Mauritiad/Mawritiad"
+    },
+    {
+        "cy": "Mexicanwr/Mecsicanwr/Mexicanes/Mecsicanes"
+    },
+    {
+        "cy": "Micronesiad"
+    },
+    {
+        "cy": "Miqueloniad"
+    },
+    {
+        "cy": "Moldofiad"
+    },
+    {
+        "cy": "Monaciad"
+    },
+    {
+        "cy": "Mongoliad"
+    },
+    {
+        "cy": "Montenegroad"
+    },
+    {
+        "cy": "Montserratiad"
+    },
+    {
+        "cy": "Morociad"
+    },
+    {
+        "cy": "Botswaniad"
+    },
+    {
+        "cy": "Mozambiquiad"
+    },
+    {
+        "cy": "Un o Myanmar (Burma)"
+    },
+    {
+        "cy": "Namibiad"
+    },
+    {
+        "cy": "Nauruad/Nawrŵad"
+    },
+    {
+        "cy": "Nepali"
+    },
+    {
+        "cy": "Un o Nevis"
+    },
+    {
+        "cy": "Un o Caledonia Newydd"
+    },
+    {
+        "cy": "Un o Seland Newydd"
+    },
+    {
+        "cy": "Nicaragwad"
+    },
+    {
+        "cy": "Nigeriad (Nigeria)"
+    },
+    {
+        "cy": "Nigeriad (Niger)"
+    },
+    {
+        "cy": "Un o Niue"
+    },
+    {
+        "cy": "Un o Vanuatu"
+    },
+    {
+        "cy": "Un o Ynys Norfolk"
+    },
+    {
+        "cy": "Un o Ogledd Korea/Un o Ogledd Corea"
+    },
+    {
+        "cy": "Gwyddel/Gwyddeles o Ogledd Iwerddon"
+    },
+    {
+        "cy": "Un o Ynysoedd Gogleddol Mariana"
+    },
+    {
+        "cy": "Norwyad"
+    },
+    {
+        "cy": "Omaniad"
+    },
+    {
+        "cy": "Pacistaniad"
+    },
+    {
+        "cy": "Palauiad"
+    },
+    {
+        "cy": "Palesteiniad"
+    },
+    {
+        "cy": "Panamaniad"
+    },
+    {
+        "cy": "Un o Papua Guinea Newydd"
+    },
+    {
+        "cy": "Paraguayad"
+    },
+    {
+        "cy": "Periwiad"
+    },
+    {
+        "cy": "Un o Ynysoedd Pitcairn"
+    },
+    {
+        "cy": "Pwyliad"
+    },
+    {
+        "cy": "Portiwgaliad"
+    },
+    {
+        "cy": "Puerto Riciad"
+    },
+    {
+        "cy": "Qatariad"
+    },
+    {
+        "cy": "Quisqueyad"
+    },
+    {
+        "cy": "Un o Réunion"
+    },
+    {
+        "cy": "Romaniad/Rwmaniad"
+    },
+    {
+        "cy": "Rwsiad"
+    },
+    {
+        "cy": "Rwandiad"
+    },
+    {
+        "cy": "Sahrawi"
+    },
+    {
+        "cy": "Un o St Helena"
+    },
+    {
+        "cy": "Un o Sint Maarten"
+    },
+    {
+        "cy": "Un o St Vincent"
+    },
+    {
+        "cy": "Un o Saint Martin"
+    },
+    {
+        "cy": "Un o St Pierre"
+    },
+    {
+        "cy": "Un o El Salvador"
+    },
+    {
+        "cy": "Un o San Marino"
+    },
+    {
+        "cy": "Samoad"
+    },
+    {
+        "cy": "Un o São Tomé a Príncipe"
+    },
+    {
+        "cy": "Un o Saudi Arabia/Un o Sawdi-Arabia"
+    },
+    {
+        "cy": "Albanwr/Albanes"
+    },
+    {
+        "cy": "Senegaliad"
+    },
+    {
+        "cy": "Serbiad"
+    },
+    {
+        "cy": "Un o Seychelles"
+    },
+    {
+        "cy": "Un o Sierra Leone"
+    },
+    {
+        "cy": "Singaporead"
+    },
+    {
+        "cy": "Slofaciad"
+    },
+    {
+        "cy": "Slofeniad"
+    },
+    {
+        "cy": "Un o Ynysoedd Solomon"
+    },
+    {
+        "cy": "Somaliad"
+    },
+    {
+        "cy": "Un o Dde Affrica"
+    },
+    {
+        "cy": "Un o Dde Georgia"
+    },
+    {
+        "cy": "Un o Dde Korea/Un o Dde Corea"
+    },
+    {
+        "cy": "Un o Ynysoedd Sandwich y De"
+    },
+    {
+        "cy": "Un o Dde Sudan"
+    },
+    {
+        "cy": "Sbaenwr/Sbaenes"
+    },
+    {
+        "cy": "Sri Lancad"
+    },
+    {
+        "cy": "Un o Saint Lucia"
+    },
+    {
+        "cy": "Un o St Lucia"
+    },
+    {
+        "cy": "Sudaniad/Swdaniad"
+    },
+    {
+        "cy": "Surinamead"
+    },
+    {
+        "cy": "Un o Svalbard a Jan Mayen"
+    },
+    {
+        "cy": "Swaziad/Un o Eswatini"
+    },
+    {
+        "cy": "Swediad"
+    },
+    {
+        "cy": "Swisiad"
+    },
+    {
+        "cy": "Syriad"
+    },
+    {
+        "cy": "Taiwaniad"
+    },
+    {
+        "cy": "Tajik"
+    },
+    {
+        "cy": "Tansanïad"
+    },
+    {
+        "cy": "Thai"
+    },
+    {
+        "cy": "Togoliad"
+    },
+    {
+        "cy": "Tokelauiad"
+    },
+    {
+        "cy": "Tongiad"
+    },
+    {
+        "cy": "Un o Trinidad a Tobago"
+    },
+    {
+        "cy": "Tunisiad/Tiwnisiad"
+    },
+    {
+        "cy": "Twrc/Tyrc"
+    },
+    {
+        "cy": "Cypriad Twrcaidd"
+    },
+    {
+        "cy": "Turkmenistaniad"
+    },
+    {
+        "cy": "Un o Ynysoedd Turks a Caicos"
+    },
+    {
+        "cy": "Tuvaluad"
+    },
+    {
+        "cy": "Ugandiad/Wgandiad"
+    },
+    {
+        "cy": "Ukrainiad/Wcraniad"
+    },
+    {
+        "cy": "Uruguayad/Wrwgwaiad"
+    },
+    {
+        "cy": "Uzbekiad/Wsbeciad"
+    },
+    {
+        "cy": "Venezueliad/Fenesweliad"
+    },
+    {
+        "cy": "Vietnamiad/Fietnamiad"
+    },
+    {
+        "cy": "Un o St Vincent a'r Grenadines"
+    },
+    {
+        "cy": "Un o Ynysoedd y Wyryf"
+    },
+    {
+        "cy": "Un o Wallis"
+    },
+    {
+        "cy": "Cymro/Cymraes"
+    },
+    {
+        "cy": "Yemeniad/Iemeniad"
+    },
+    {
+        "cy": "Zambiad/Sambiad"
+    },
+    {
+        "cy": "Zimbabwead/Simbabwead"
+    }
 ]

--- a/data/gb/cy/passport-countries.json
+++ b/data/gb/cy/passport-countries.json
@@ -1,201 +1,599 @@
 [
-    "Y Deyrnas Unedig",
-    "Iwerddon",
-    "Affganistan",
-    "Albania",
-    "Algeria",
-    "Andorra",
-    "Angola",
-    "Antigua a Barbuda",
-    "Ariannin",
-    "Armenia",
-    "Awstralia",
-    "Awstria",
-    "Azerbaijan",
-    "Bahrain",
-    "Bangladesh",
-    "Barbados",
-    "Belarws",
-    "Gwlad Belg",
-    "Belize",
-    "Benin",
-    "Bhutan",
-    "Bolifia",
-    "Bosnia a Herzegovina",
-    "Botswana",
-    "Brasil",
-    "Brunei",
-    "Bwlgaria",
-    "Burkina Faso",
-    "Burundi",
-    "Cambodia",
-    "Cameroon",
-    "Canada",
-    "Cabo Verde",
-    "Gweriniaeth Canol Affrica",
-    "Chad",
-    "Chile",
-    "Tsieina",
-    "Colombia",
-    "Comoros",
-    "Congo",
-    "Congo (Gweriniaeth Ddemocrataidd)",
-    "Costa Rica",
-    "Croatia",
-    "Cuba",
-    "Cyprus",
-    "Czechia",
-    "Denmarc",
-    "Djibouti",
-    "Dominica",
-    "Gweriniaeth Dominica",
-    "Dwyrain Timor",
-    "Ecuador",
-    "Yr Aifft",
-    "El Salvador",
-    "Guinea Gyhydeddol",
-    "Eritrea",
-    "Estonia",
-    "Eswatini",
-    "Ethiopia",
-    "Ffiji",
-    "Y Ffindir",
-    "Ffrainc",
-    "Gabon",
-    "Georgia",
-    "Yr Almaen",
-    "Ghana",
-    "Gwlad Groeg",
-    "Grenada",
-    "Guatemala",
-    "Guinea",
-    "Guinea-Bissau",
-    "Guyana",
-    "Haiti",
-    "Honduras",
-    "Hong Kong",
-    "Hwngari",
-    "Gwlad yr Iâ",
-    "India",
-    "Indonesia",
-    "Iran",
-    "Irac",
-    "Israel",
-    "Yr Eidal",
-    "Y Traeth Ifori",
-    "Jamaica",
-    "Japan",
-    "Gwlad yr Iorddonen",
-    "Kazakhstan",
-    "Kenya",
-    "Kiribati",
-    "Kosovo",
-    "Kuwait",
-    "Kyrgyzstan",
-    "Laos",
-    "Latfia",
-    "Libanus",
-    "Lesotho",
-    "Liberia",
-    "Libya",
-    "Liechtenstein",
-    "Lithwania",
-    "Lwcsembwrg",
-    "Macao",
-    "Madagasgar",
-    "Malawi",
-    "Malaysia",
-    "Maldives",
-    "Mali",
-    "Malta",
-    "Ynysoedd Marshall",
-    "Mauritania",
-    "Mauritius",
-    "Mecsico",
-    "Micronesia",
-    "Moldofa",
-    "Monaco",
-    "Mongolia",
-    "Montenegro",
-    "Moroco",
-    "Mozambique",
-    "Myanmar (Burma)",
-    "Namibia",
-    "Nauru",
-    "Nepal",
-    "Yr Iseldiroedd",
-    "Seland Newydd",
-    "Nicaragua",
-    "Niger",
-    "Nigeria",
-    "Gogledd Korea",
-    "Gogledd Macedonia",
-    "Norwy",
-    "Tiriogaethau Meddianedig Palesteina",
-    "Oman",
-    "Pacistan",
-    "Palau",
-    "Panama",
-    "Papua Guinea Newydd",
-    "Paraguay",
-    "Periw",
-    "Pilipinas (Ynysoedd Philippines)",
-    "Gwlad Pwyl",
-    "Portiwgal",
-    "Qatar",
-    "Rwmania",
-    "Rwsia",
-    "Rwanda",
-    "Samoa",
-    "San Marino",
-    "Sao Tome a Principe",
-    "Saudi Arabia",
-    "Senegal",
-    "Serbia",
-    "Seychelles",
-    "Sierra Leone",
-    "Singapore",
-    "Slofacia",
-    "Slofenia",
-    "Ynysoedd Solomon",
-    "Somalia",
-    "De Affrica",
-    "De Korea",
-    "De Sudan",
-    "Sbaen (gan gynnwys Ynysoedd Baleares)",
-    "Sri Lanka",
-    "St Kitts a Nevis",
-    "St Lucia",
-    "St Vincent a'r Grenadines",
-    "Sudan",
-    "Suriname",
-    "Sweden",
-    "Y Swistir",
-    "Syria",
-    "Taiwan",
-    "Tajikistan",
-    "Tanzania",
-    "Gwlad Thai",
-    "Y Bahamas",
-    "Y Gambia",
-    "Togo",
-    "Tonga",
-    "Trinidad a Tobago",
-    "Tunisia",
-    "Twrci",
-    "Turkmenistan",
-    "Tuvalu",
-    "Uganda",
-    "Ukrain",
-    "Yr Emiraethau Arabaidd Unedig",
-    "Unol Daleithiau America",
-    "Uruguay",
-    "Uzbekistan",
-    "Vanuatu",
-    "Dinas y Fatican",
-    "Venezuela",
-    "Fiet-nam",
-    "Yemen",
-    "Zambia",
-    "Zimbabwe"
+    {
+        "cy": "Y Deyrnas Unedig"
+    },
+    {
+        "cy": "Iwerddon"
+    },
+    {
+        "cy": "Affganistan"
+    },
+    {
+        "cy": "Albania"
+    },
+    {
+        "cy": "Algeria"
+    },
+    {
+        "cy": "Andorra"
+    },
+    {
+        "cy": "Angola"
+    },
+    {
+        "cy": "Antigua a Barbuda"
+    },
+    {
+        "cy": "Ariannin"
+    },
+    {
+        "cy": "Armenia"
+    },
+    {
+        "cy": "Awstralia"
+    },
+    {
+        "cy": "Awstria"
+    },
+    {
+        "cy": "Azerbaijan"
+    },
+    {
+        "cy": "Bahrain"
+    },
+    {
+        "cy": "Bangladesh"
+    },
+    {
+        "cy": "Barbados"
+    },
+    {
+        "cy": "Belarws"
+    },
+    {
+        "cy": "Gwlad Belg"
+    },
+    {
+        "cy": "Belize"
+    },
+    {
+        "cy": "Benin"
+    },
+    {
+        "cy": "Bhutan"
+    },
+    {
+        "cy": "Bolifia"
+    },
+    {
+        "cy": "Bosnia a Herzegovina"
+    },
+    {
+        "cy": "Botswana"
+    },
+    {
+        "cy": "Brasil"
+    },
+    {
+        "cy": "Brunei"
+    },
+    {
+        "cy": "Bwlgaria"
+    },
+    {
+        "cy": "Burkina Faso"
+    },
+    {
+        "cy": "Burundi"
+    },
+    {
+        "cy": "Cambodia"
+    },
+    {
+        "cy": "Cameroon"
+    },
+    {
+        "cy": "Canada"
+    },
+    {
+        "cy": "Cabo Verde"
+    },
+    {
+        "cy": "Gweriniaeth Canol Affrica"
+    },
+    {
+        "cy": "Chad"
+    },
+    {
+        "cy": "Chile"
+    },
+    {
+        "cy": "Tsieina"
+    },
+    {
+        "cy": "Colombia"
+    },
+    {
+        "cy": "Comoros"
+    },
+    {
+        "cy": "Congo"
+    },
+    {
+        "cy": "Congo (Gweriniaeth Ddemocrataidd)"
+    },
+    {
+        "cy": "Costa Rica"
+    },
+    {
+        "cy": "Croatia"
+    },
+    {
+        "cy": "Cuba"
+    },
+    {
+        "cy": "Cyprus"
+    },
+    {
+        "cy": "Czechia"
+    },
+    {
+        "cy": "Denmarc"
+    },
+    {
+        "cy": "Djibouti"
+    },
+    {
+        "cy": "Dominica"
+    },
+    {
+        "cy": "Gweriniaeth Dominica"
+    },
+    {
+        "cy": "Dwyrain Timor"
+    },
+    {
+        "cy": "Ecuador"
+    },
+    {
+        "cy": "Yr Aifft"
+    },
+    {
+        "cy": "El Salvador"
+    },
+    {
+        "cy": "Guinea Gyhydeddol"
+    },
+    {
+        "cy": "Eritrea"
+    },
+    {
+        "cy": "Estonia"
+    },
+    {
+        "cy": "Eswatini"
+    },
+    {
+        "cy": "Ethiopia"
+    },
+    {
+        "cy": "Ffiji"
+    },
+    {
+        "cy": "Y Ffindir"
+    },
+    {
+        "cy": "Ffrainc"
+    },
+    {
+        "cy": "Gabon"
+    },
+    {
+        "cy": "Georgia"
+    },
+    {
+        "cy": "Yr Almaen"
+    },
+    {
+        "cy": "Ghana"
+    },
+    {
+        "cy": "Gwlad Groeg"
+    },
+    {
+        "cy": "Grenada"
+    },
+    {
+        "cy": "Guatemala"
+    },
+    {
+        "cy": "Guinea"
+    },
+    {
+        "cy": "Guinea-Bissau"
+    },
+    {
+        "cy": "Guyana"
+    },
+    {
+        "cy": "Haiti"
+    },
+    {
+        "cy": "Honduras"
+    },
+    {
+        "cy": "Hong Kong"
+    },
+    {
+        "cy": "Hwngari"
+    },
+    {
+        "cy": "Gwlad yr Iâ"
+    },
+    {
+        "cy": "India"
+    },
+    {
+        "cy": "Indonesia"
+    },
+    {
+        "cy": "Iran"
+    },
+    {
+        "cy": "Irac"
+    },
+    {
+        "cy": "Israel"
+    },
+    {
+        "cy": "Yr Eidal"
+    },
+    {
+        "cy": "Y Traeth Ifori"
+    },
+    {
+        "cy": "Jamaica"
+    },
+    {
+        "cy": "Japan"
+    },
+    {
+        "cy": "Gwlad yr Iorddonen"
+    },
+    {
+        "cy": "Kazakhstan"
+    },
+    {
+        "cy": "Kenya"
+    },
+    {
+        "cy": "Kiribati"
+    },
+    {
+        "cy": "Kosovo"
+    },
+    {
+        "cy": "Kuwait"
+    },
+    {
+        "cy": "Kyrgyzstan"
+    },
+    {
+        "cy": "Laos"
+    },
+    {
+        "cy": "Latfia"
+    },
+    {
+        "cy": "Libanus"
+    },
+    {
+        "cy": "Lesotho"
+    },
+    {
+        "cy": "Liberia"
+    },
+    {
+        "cy": "Libya"
+    },
+    {
+        "cy": "Liechtenstein"
+    },
+    {
+        "cy": "Lithwania"
+    },
+    {
+        "cy": "Lwcsembwrg"
+    },
+    {
+        "cy": "Macao"
+    },
+    {
+        "cy": "Madagasgar"
+    },
+    {
+        "cy": "Malawi"
+    },
+    {
+        "cy": "Malaysia"
+    },
+    {
+        "cy": "Maldives"
+    },
+    {
+        "cy": "Mali"
+    },
+    {
+        "cy": "Malta"
+    },
+    {
+        "cy": "Ynysoedd Marshall"
+    },
+    {
+        "cy": "Mauritania"
+    },
+    {
+        "cy": "Mauritius"
+    },
+    {
+        "cy": "Mecsico"
+    },
+    {
+        "cy": "Micronesia"
+    },
+    {
+        "cy": "Moldofa"
+    },
+    {
+        "cy": "Monaco"
+    },
+    {
+        "cy": "Mongolia"
+    },
+    {
+        "cy": "Montenegro"
+    },
+    {
+        "cy": "Moroco"
+    },
+    {
+        "cy": "Mozambique"
+    },
+    {
+        "cy": "Myanmar (Burma)"
+    },
+    {
+        "cy": "Namibia"
+    },
+    {
+        "cy": "Nauru"
+    },
+    {
+        "cy": "Nepal"
+    },
+    {
+        "cy": "Yr Iseldiroedd"
+    },
+    {
+        "cy": "Seland Newydd"
+    },
+    {
+        "cy": "Nicaragua"
+    },
+    {
+        "cy": "Niger"
+    },
+    {
+        "cy": "Nigeria"
+    },
+    {
+        "cy": "Gogledd Korea"
+    },
+    {
+        "cy": "Gogledd Macedonia"
+    },
+    {
+        "cy": "Norwy"
+    },
+    {
+        "cy": "Tiriogaethau Meddianedig Palesteina"
+    },
+    {
+        "cy": "Oman"
+    },
+    {
+        "cy": "Pacistan"
+    },
+    {
+        "cy": "Palau"
+    },
+    {
+        "cy": "Panama"
+    },
+    {
+        "cy": "Papua Guinea Newydd"
+    },
+    {
+        "cy": "Paraguay"
+    },
+    {
+        "cy": "Periw"
+    },
+    {
+        "cy": "Pilipinas (Ynysoedd Philippines)"
+    },
+    {
+        "cy": "Gwlad Pwyl"
+    },
+    {
+        "cy": "Portiwgal"
+    },
+    {
+        "cy": "Qatar"
+    },
+    {
+        "cy": "Rwmania"
+    },
+    {
+        "cy": "Rwsia"
+    },
+    {
+        "cy": "Rwanda"
+    },
+    {
+        "cy": "Samoa"
+    },
+    {
+        "cy": "San Marino"
+    },
+    {
+        "cy": "Sao Tome a Principe"
+    },
+    {
+        "cy": "Saudi Arabia"
+    },
+    {
+        "cy": "Senegal"
+    },
+    {
+        "cy": "Serbia"
+    },
+    {
+        "cy": "Seychelles"
+    },
+    {
+        "cy": "Sierra Leone"
+    },
+    {
+        "cy": "Singapore"
+    },
+    {
+        "cy": "Slofacia"
+    },
+    {
+        "cy": "Slofenia"
+    },
+    {
+        "cy": "Ynysoedd Solomon"
+    },
+    {
+        "cy": "Somalia"
+    },
+    {
+        "cy": "De Affrica"
+    },
+    {
+        "cy": "De Korea"
+    },
+    {
+        "cy": "De Sudan"
+    },
+    {
+        "cy": "Sbaen (gan gynnwys Ynysoedd Baleares)"
+    },
+    {
+        "cy": "Sri Lanka"
+    },
+    {
+        "cy": "St Kitts a Nevis"
+    },
+    {
+        "cy": "St Lucia"
+    },
+    {
+        "cy": "St Vincent a'r Grenadines"
+    },
+    {
+        "cy": "Sudan"
+    },
+    {
+        "cy": "Suriname"
+    },
+    {
+        "cy": "Sweden"
+    },
+    {
+        "cy": "Y Swistir"
+    },
+    {
+        "cy": "Syria"
+    },
+    {
+        "cy": "Taiwan"
+    },
+    {
+        "cy": "Tajikistan"
+    },
+    {
+        "cy": "Tanzania"
+    },
+    {
+        "cy": "Gwlad Thai"
+    },
+    {
+        "cy": "Y Bahamas"
+    },
+    {
+        "cy": "Y Gambia"
+    },
+    {
+        "cy": "Togo"
+    },
+    {
+        "cy": "Tonga"
+    },
+    {
+        "cy": "Trinidad a Tobago"
+    },
+    {
+        "cy": "Tunisia"
+    },
+    {
+        "cy": "Twrci"
+    },
+    {
+        "cy": "Turkmenistan"
+    },
+    {
+        "cy": "Tuvalu"
+    },
+    {
+        "cy": "Uganda"
+    },
+    {
+        "cy": "Ukrain"
+    },
+    {
+        "cy": "Yr Emiraethau Arabaidd Unedig"
+    },
+    {
+        "cy": "Unol Daleithiau America"
+    },
+    {
+        "cy": "Uruguay"
+    },
+    {
+        "cy": "Uzbekistan"
+    },
+    {
+        "cy": "Vanuatu"
+    },
+    {
+        "cy": "Dinas y Fatican"
+    },
+    {
+        "cy": "Venezuela"
+    },
+    {
+        "cy": "Fiet-nam"
+    },
+    {
+        "cy": "Yemen"
+    },
+    {
+        "cy": "Zambia"
+    },
+    {
+        "cy": "Zimbabwe"
+    }
 ]

--- a/data/gb/cy/religions.json
+++ b/data/gb/cy/religions.json
@@ -1,67 +1,197 @@
 [
-    "Agnostig",
-    "Mwslim Ahmadi/Moslem Ahmadi",
-    "Alevi",
-    "Anglicaniad",
-    "Anffyddiwr/Anffyddwraig",
-    "Bahai",
-    "Bedyddiwr/Bedyddwraig",
-    "Cristion Ailanedig",
-    "Bwdhydd",
-    "Catholig/Pabydd/Pabyddes",
-    "Capel",
-    "Cristadelffiad",
-    "Cristion",
-    "Cristion Uniongred",
-    "Eglwys yng Nghymru",
-    "Eglwys Crist",
-    "Eglwys Loegr",
-    "Eglwys Duw",
-    "Eglwys yr Alban",
-    "Coptig Uniongred",
-    "Dëist",
-    "Derwydd",
-    "Efengylaidd",
-    "Gnostig",
-    "Uniongred Groegaidd",
-    "Hare Krishna",
-    "Hindŵ",
-    "Holistaidd",
-    "Annibynnol",
-    "Jain",
-    "Tyst Jehovah",
-    "Iddewig",
-    "Kirat",
-    "Saint y Dyddiau Diwethaf",
-    "Lutheriad",
-    "Methodist",
-    "Mormon",
-    "Mwslim/Moslem",
-    "Dim Crefydd",
-    "Pagan",
-    "Pantheist",
-    "Pentecostiad",
-    "Presbyteriad",
-    "Protestant",
-    "Crynwr/Crynwraig",
-    "Rastaffariad",
-    "Ravidassia",
-    "Catholig Eglwys Rufain/Pabydd Eglwys Rufain/Pabyddes Eglwys Rufain",
-    "Uniongred Rwsiaidd",
-    "Byddin yr Iachawdwriaeth",
-    "Satanydd",
-    "Seientoleg",
-    "Uniongred Serbaidd",
-    "Adfentydd y Seithfed Dydd",
-    "Shinto",
-    "Sikh",
-    "Ysbrydol",
-    "Ysbrydegydd",
-    "Taöydd",
-    "Theistiad",
-    "Undodwr",
-    "Bedyddiwr Cymreig/Bedyddwraig Gymreig",
-    "Wiccan",
-    "Yazidi",
-    "Zoroastriad"
+    {
+        "cy": "Agnostig"
+    },
+    {
+        "cy": "Mwslim Ahmadi/Moslem Ahmadi"
+    },
+    {
+        "cy": "Alevi"
+    },
+    {
+        "cy": "Anglicaniad"
+    },
+    {
+        "cy": "Anffyddiwr/Anffyddwraig"
+    },
+    {
+        "cy": "Bahai"
+    },
+    {
+        "cy": "Bedyddiwr/Bedyddwraig"
+    },
+    {
+        "cy": "Cristion Ailanedig"
+    },
+    {
+        "cy": "Bwdhydd"
+    },
+    {
+        "cy": "Catholig/Pabydd/Pabyddes"
+    },
+    {
+        "cy": "Capel"
+    },
+    {
+        "cy": "Cristadelffiad"
+    },
+    {
+        "cy": "Cristion"
+    },
+    {
+        "cy": "Cristion Uniongred"
+    },
+    {
+        "cy": "Eglwys yng Nghymru"
+    },
+    {
+        "cy": "Eglwys Crist"
+    },
+    {
+        "cy": "Eglwys Loegr"
+    },
+    {
+        "cy": "Eglwys Duw"
+    },
+    {
+        "cy": "Eglwys yr Alban"
+    },
+    {
+        "cy": "Coptig Uniongred"
+    },
+    {
+        "cy": "Dëist"
+    },
+    {
+        "cy": "Derwydd"
+    },
+    {
+        "cy": "Efengylaidd"
+    },
+    {
+        "cy": "Gnostig"
+    },
+    {
+        "cy": "Uniongred Groegaidd"
+    },
+    {
+        "cy": "Hare Krishna"
+    },
+    {
+        "cy": "Hindŵ"
+    },
+    {
+        "cy": "Holistaidd"
+    },
+    {
+        "cy": "Annibynnol"
+    },
+    {
+        "cy": "Jain"
+    },
+    {
+        "cy": "Tyst Jehovah"
+    },
+    {
+        "cy": "Iddewig"
+    },
+    {
+        "cy": "Kirat"
+    },
+    {
+        "cy": "Saint y Dyddiau Diwethaf"
+    },
+    {
+        "cy": "Lutheriad"
+    },
+    {
+        "cy": "Methodist"
+    },
+    {
+        "cy": "Mormon"
+    },
+    {
+        "cy": "Mwslim/Moslem"
+    },
+    {
+        "cy": "Dim Crefydd"
+    },
+    {
+        "cy": "Pagan"
+    },
+    {
+        "cy": "Pantheist"
+    },
+    {
+        "cy": "Pentecostiad"
+    },
+    {
+        "cy": "Presbyteriad"
+    },
+    {
+        "cy": "Protestant"
+    },
+    {
+        "cy": "Crynwr/Crynwraig"
+    },
+    {
+        "cy": "Rastaffariad"
+    },
+    {
+        "cy": "Ravidassia"
+    },
+    {
+        "cy": "Catholig Eglwys Rufain/Pabydd Eglwys Rufain/Pabyddes Eglwys Rufain"
+    },
+    {
+        "cy": "Uniongred Rwsiaidd"
+    },
+    {
+        "cy": "Byddin yr Iachawdwriaeth"
+    },
+    {
+        "cy": "Satanydd"
+    },
+    {
+        "cy": "Seientoleg"
+    },
+    {
+        "cy": "Uniongred Serbaidd"
+    },
+    {
+        "cy": "Adfentydd y Seithfed Dydd"
+    },
+    {
+        "cy": "Shinto"
+    },
+    {
+        "cy": "Sikh"
+    },
+    {
+        "cy": "Ysbrydol"
+    },
+    {
+        "cy": "Ysbrydegydd"
+    },
+    {
+        "cy": "Taöydd"
+    },
+    {
+        "cy": "Theistiad"
+    },
+    {
+        "cy": "Undodwr"
+    },
+    {
+        "cy": "Bedyddiwr Cymreig/Bedyddwraig Gymreig"
+    },
+    {
+        "cy": "Wiccan"
+    },
+    {
+        "cy": "Yazidi"
+    },
+    {
+        "cy": "Zoroastriad"
+    }
 ]

--- a/data/gb/en/countries-of-birth.json
+++ b/data/gb/en/countries-of-birth.json
@@ -1,254 +1,758 @@
 [
-    "England",
-    "Wales",
-    "Scotland",
-    "Northern Ireland",
-    "Republic of Ireland",
-    "Afghanistan",
-    "Åland Islands",
-    "Albania",
-    "Algeria",
-    "American Samoa",
-    "Andorra",
-    "Angola",
-    "Anguilla",
-    "Antigua and Barbuda",
-    "Argentina",
-    "Armenia",
-    "Aruba",
-    "Australia",
-    "Austria",
-    "Azerbaijan",
-    "Barbados",
-    "Bahrain",
-    "Bangladesh",
-    "Belarus",
-    "Belgium",
-    "Belize",
-    "Benin",
-    "Bermuda",
-    "Bhutan",
-    "Bolivia",
-    "Bonaire, Sint Eustatius and Saba",
-    "Bosnia and Herzegovina",
-    "Botswana",
-    "Bouvet Island",
-    "Brazil",
-    "British Indian Ocean Territory",
-    "British Virgin Islands",
-    "Brunei",
-    "Bulgaria",
-    "Burkina Faso",
-    "Burundi",
-    "Cambodia",
-    "Cameroon",
-    "Canada",
-    "Canary Islands",
-    "Cape Verde",
-    "Cayman Islands",
-    "Central African Republic",
-    "Chad",
-    "Channel Islands",
-    "Chile",
-    "China",
-    "Christmas Island",
-    "Cocos (Keeling) Islands",
-    "Colombia",
-    "Comoros",
-    "Congo",
-    "Congo (Democratic Republic)",
-    "Cook Islands",
-    "Costa Rica",
-    "Croatia",
-    "Cuba",
-    "Curaçao",
-    "Cyprus",
-    "Czechia",
-    "Denmark",
-    "Djibouti",
-    "Dominica",
-    "Dominican Republic",
-    "East Timor",
-    "Ecuador",
-    "Egypt",
-    "El Salvador",
-    "Equatorial Guinea",
-    "Eritrea",
-    "Estonia",
-    "Eswatini",
-    "Ethiopia",
-    "Falkland Islands",
-    "Faroe Islands",
-    "Fiji",
-    "Finland",
-    "France",
-    "French Guiana",
-    "French Polynesia",
-    "French Southern Territories",
-    "Gabon",
-    "Georgia",
-    "Germany",
-    "Ghana",
-    "Gibraltar",
-    "Greece",
-    "Greenland",
-    "Grenada",
-    "Guadeloupe",
-    "Guam",
-    "Guatemala",
-    "Guinea",
-    "Guinea-Bissau",
-    "Guyana",
-    "Haiti",
-    "Heard Island and McDonald Islands",
-    "Honduras",
-    "Hong Kong",
-    "Hungary",
-    "Iceland",
-    "India",
-    "Indonesia",
-    "Iran",
-    "Iraq",
-    "Isle of Man",
-    "Israel",
-    "Italy",
-    "Ivory Coast",
-    "Jamaica",
-    "Japan",
-    "Jordan",
-    "Kazakhstan",
-    "Kenya",
-    "Kiribati",
-    "Kosovo",
-    "Kuwait",
-    "Kyrgyzstan",
-    "Laos",
-    "Latvia",
-    "Lebanon",
-    "Lesotho",
-    "Liberia",
-    "Libya",
-    "Liechtenstein",
-    "Lithuania",
-    "Luxembourg",
-    "Macao",
-    "Madagascar",
-    "Malawi",
-    "Malaysia",
-    "Maldives",
-    "Mali",
-    "Malta",
-    "Marshall Islands",
-    "Martinique",
-    "Mauritania",
-    "Mauritius",
-    "Mayotte",
-    "Mexico",
-    "Micronesia",
-    "Moldova",
-    "Monaco",
-    "Mongolia",
-    "Montenegro",
-    "Montserrat",
-    "Morocco",
-    "Mozambique",
-    "Myanmar (Burma)",
-    "Namibia",
-    "Nauru",
-    "Nepal",
-    "The Netherlands",
-    "New Caledonia",
-    "New Zealand",
-    "Nicaragua",
-    "Niger",
-    "Nigeria",
-    "Niue",
-    "Norfolk Island",
-    "North Korea",
-    "North Macedonia",
-    "Northern Mariana Islands",
-    "Norway",
-    "Occupied Palestinian Territories",
-    "Oman",
-    "Pakistan",
-    "Palau",
-    "Panama",
-    "Papua New Guinea",
-    "Paraguay",
-    "Peru",
-    "Philippines",
-    "Pitcairn, Henderson, Ducie and Oeno Islands",
-    "Poland",
-    "Portugal",
-    "Puerto Rico",
-    "Qatar",
-    "Réunion",
-    "Romania",
-    "Russia",
-    "Rwanda",
-    "Saint Martin (French part)",
-    "Samoa",
-    "San Marino",
-    "São Tomé and Príncipe",
-    "Saudi Arabia",
-    "Senegal",
-    "Serbia",
-    "Seychelles",
-    "Sierra Leone",
-    "Singapore",
-    "Sint Maarten (Dutch Part)",
-    "Slovakia",
-    "Slovenia",
-    "Solomon Islands",
-    "Somalia",
-    "South Africa",
-    "South Georgia and the South Sandwich Islands",
-    "South Korea",
-    "South Sudan",
-    "Spain (including Balearic Islands)",
-    "Sri Lanka",
-    "St Barthélemy",
-    "St Helena, Ascension and Tristan da Cunha",
-    "St Kitts and Nevis",
-    "St Lucia",
-    "St Pierre and Miquelon",
-    "St Vincent and the Grenadines",
-    "Sudan",
-    "Suriname",
-    "Svalbard and Jan Mayen",
-    "Sweden",
-    "Switzerland",
-    "Syria",
-    "Taiwan",
-    "Tajikistan",
-    "Tanzania",
-    "Thailand",
-    "The Bahamas",
-    "The Gambia",
-    "Togo",
-    "Tokelau",
-    "Tonga",
-    "Trinidad and Tobago",
-    "Tunisia",
-    "Turkey",
-    "Turkmenistan",
-    "Turks and Caicos Islands",
-    "Tuvalu",
-    "Uganda",
-    "Ukraine",
-    "United Arab Emirates",
-    "United States minor outlying islands",
-    "United States of America",
-    "United States Virgin Islands",
-    "Uruguay",
-    "Uzbekistan",
-    "Vanuatu",
-    "Vatican City",
-    "Venezuela",
-    "Vietnam",
-    "Wallis and Futuna",
-    "Western Sahara",
-    "Yemen",
-    "Zambia",
-    "Zimbabwe"
+    {
+        "en": "England"
+    },
+    {
+        "en": "Wales"
+    },
+    {
+        "en": "Scotland"
+    },
+    {
+        "en": "Northern Ireland"
+    },
+    {
+        "en": "Republic of Ireland"
+    },
+    {
+        "en": "Afghanistan"
+    },
+    {
+        "en": "Åland Islands"
+    },
+    {
+        "en": "Albania"
+    },
+    {
+        "en": "Algeria"
+    },
+    {
+        "en": "American Samoa"
+    },
+    {
+        "en": "Andorra"
+    },
+    {
+        "en": "Angola"
+    },
+    {
+        "en": "Anguilla"
+    },
+    {
+        "en": "Antigua and Barbuda"
+    },
+    {
+        "en": "Argentina"
+    },
+    {
+        "en": "Armenia"
+    },
+    {
+        "en": "Aruba"
+    },
+    {
+        "en": "Australia"
+    },
+    {
+        "en": "Austria"
+    },
+    {
+        "en": "Azerbaijan"
+    },
+    {
+        "en": "Barbados"
+    },
+    {
+        "en": "Bahrain"
+    },
+    {
+        "en": "Bangladesh"
+    },
+    {
+        "en": "Belarus"
+    },
+    {
+        "en": "Belgium"
+    },
+    {
+        "en": "Belize"
+    },
+    {
+        "en": "Benin"
+    },
+    {
+        "en": "Bermuda"
+    },
+    {
+        "en": "Bhutan"
+    },
+    {
+        "en": "Bolivia"
+    },
+    {
+        "en": "Bonaire, Sint Eustatius and Saba"
+    },
+    {
+        "en": "Bosnia and Herzegovina"
+    },
+    {
+        "en": "Botswana"
+    },
+    {
+        "en": "Bouvet Island"
+    },
+    {
+        "en": "Brazil"
+    },
+    {
+        "en": "British Indian Ocean Territory"
+    },
+    {
+        "en": "British Virgin Islands"
+    },
+    {
+        "en": "Brunei"
+    },
+    {
+        "en": "Bulgaria"
+    },
+    {
+        "en": "Burkina Faso"
+    },
+    {
+        "en": "Burundi"
+    },
+    {
+        "en": "Cambodia"
+    },
+    {
+        "en": "Cameroon"
+    },
+    {
+        "en": "Canada"
+    },
+    {
+        "en": "Canary Islands"
+    },
+    {
+        "en": "Cape Verde"
+    },
+    {
+        "en": "Cayman Islands"
+    },
+    {
+        "en": "Central African Republic"
+    },
+    {
+        "en": "Chad"
+    },
+    {
+        "en": "Channel Islands"
+    },
+    {
+        "en": "Chile"
+    },
+    {
+        "en": "China"
+    },
+    {
+        "en": "Christmas Island"
+    },
+    {
+        "en": "Cocos (Keeling) Islands"
+    },
+    {
+        "en": "Colombia"
+    },
+    {
+        "en": "Comoros"
+    },
+    {
+        "en": "Congo"
+    },
+    {
+        "en": "Congo (Democratic Republic)"
+    },
+    {
+        "en": "Cook Islands"
+    },
+    {
+        "en": "Costa Rica"
+    },
+    {
+        "en": "Croatia"
+    },
+    {
+        "en": "Cuba"
+    },
+    {
+        "en": "Curaçao"
+    },
+    {
+        "en": "Cyprus"
+    },
+    {
+        "en": "Czechia"
+    },
+    {
+        "en": "Denmark"
+    },
+    {
+        "en": "Djibouti"
+    },
+    {
+        "en": "Dominica"
+    },
+    {
+        "en": "Dominican Republic"
+    },
+    {
+        "en": "East Timor"
+    },
+    {
+        "en": "Ecuador"
+    },
+    {
+        "en": "Egypt"
+    },
+    {
+        "en": "El Salvador"
+    },
+    {
+        "en": "Equatorial Guinea"
+    },
+    {
+        "en": "Eritrea"
+    },
+    {
+        "en": "Estonia"
+    },
+    {
+        "en": "Eswatini"
+    },
+    {
+        "en": "Ethiopia"
+    },
+    {
+        "en": "Falkland Islands"
+    },
+    {
+        "en": "Faroe Islands"
+    },
+    {
+        "en": "Fiji"
+    },
+    {
+        "en": "Finland"
+    },
+    {
+        "en": "France"
+    },
+    {
+        "en": "French Guiana"
+    },
+    {
+        "en": "French Polynesia"
+    },
+    {
+        "en": "French Southern Territories"
+    },
+    {
+        "en": "Gabon"
+    },
+    {
+        "en": "Georgia"
+    },
+    {
+        "en": "Germany"
+    },
+    {
+        "en": "Ghana"
+    },
+    {
+        "en": "Gibraltar"
+    },
+    {
+        "en": "Greece"
+    },
+    {
+        "en": "Greenland"
+    },
+    {
+        "en": "Grenada"
+    },
+    {
+        "en": "Guadeloupe"
+    },
+    {
+        "en": "Guam"
+    },
+    {
+        "en": "Guatemala"
+    },
+    {
+        "en": "Guinea"
+    },
+    {
+        "en": "Guinea-Bissau"
+    },
+    {
+        "en": "Guyana"
+    },
+    {
+        "en": "Haiti"
+    },
+    {
+        "en": "Heard Island and McDonald Islands"
+    },
+    {
+        "en": "Honduras"
+    },
+    {
+        "en": "Hong Kong"
+    },
+    {
+        "en": "Hungary"
+    },
+    {
+        "en": "Iceland"
+    },
+    {
+        "en": "India"
+    },
+    {
+        "en": "Indonesia"
+    },
+    {
+        "en": "Iran"
+    },
+    {
+        "en": "Iraq"
+    },
+    {
+        "en": "Isle of Man"
+    },
+    {
+        "en": "Israel"
+    },
+    {
+        "en": "Italy"
+    },
+    {
+        "en": "Ivory Coast"
+    },
+    {
+        "en": "Jamaica"
+    },
+    {
+        "en": "Japan"
+    },
+    {
+        "en": "Jordan"
+    },
+    {
+        "en": "Kazakhstan"
+    },
+    {
+        "en": "Kenya"
+    },
+    {
+        "en": "Kiribati"
+    },
+    {
+        "en": "Kosovo"
+    },
+    {
+        "en": "Kuwait"
+    },
+    {
+        "en": "Kyrgyzstan"
+    },
+    {
+        "en": "Laos"
+    },
+    {
+        "en": "Latvia"
+    },
+    {
+        "en": "Lebanon"
+    },
+    {
+        "en": "Lesotho"
+    },
+    {
+        "en": "Liberia"
+    },
+    {
+        "en": "Libya"
+    },
+    {
+        "en": "Liechtenstein"
+    },
+    {
+        "en": "Lithuania"
+    },
+    {
+        "en": "Luxembourg"
+    },
+    {
+        "en": "Macao"
+    },
+    {
+        "en": "Madagascar"
+    },
+    {
+        "en": "Malawi"
+    },
+    {
+        "en": "Malaysia"
+    },
+    {
+        "en": "Maldives"
+    },
+    {
+        "en": "Mali"
+    },
+    {
+        "en": "Malta"
+    },
+    {
+        "en": "Marshall Islands"
+    },
+    {
+        "en": "Martinique"
+    },
+    {
+        "en": "Mauritania"
+    },
+    {
+        "en": "Mauritius"
+    },
+    {
+        "en": "Mayotte"
+    },
+    {
+        "en": "Mexico"
+    },
+    {
+        "en": "Micronesia"
+    },
+    {
+        "en": "Moldova"
+    },
+    {
+        "en": "Monaco"
+    },
+    {
+        "en": "Mongolia"
+    },
+    {
+        "en": "Montenegro"
+    },
+    {
+        "en": "Montserrat"
+    },
+    {
+        "en": "Morocco"
+    },
+    {
+        "en": "Mozambique"
+    },
+    {
+        "en": "Myanmar (Burma)"
+    },
+    {
+        "en": "Namibia"
+    },
+    {
+        "en": "Nauru"
+    },
+    {
+        "en": "Nepal"
+    },
+    {
+        "en": "The Netherlands"
+    },
+    {
+        "en": "New Caledonia"
+    },
+    {
+        "en": "New Zealand"
+    },
+    {
+        "en": "Nicaragua"
+    },
+    {
+        "en": "Niger"
+    },
+    {
+        "en": "Nigeria"
+    },
+    {
+        "en": "Niue"
+    },
+    {
+        "en": "Norfolk Island"
+    },
+    {
+        "en": "North Korea"
+    },
+    {
+        "en": "North Macedonia"
+    },
+    {
+        "en": "Northern Mariana Islands"
+    },
+    {
+        "en": "Norway"
+    },
+    {
+        "en": "Occupied Palestinian Territories"
+    },
+    {
+        "en": "Oman"
+    },
+    {
+        "en": "Pakistan"
+    },
+    {
+        "en": "Palau"
+    },
+    {
+        "en": "Panama"
+    },
+    {
+        "en": "Papua New Guinea"
+    },
+    {
+        "en": "Paraguay"
+    },
+    {
+        "en": "Peru"
+    },
+    {
+        "en": "Philippines"
+    },
+    {
+        "en": "Pitcairn, Henderson, Ducie and Oeno Islands"
+    },
+    {
+        "en": "Poland"
+    },
+    {
+        "en": "Portugal"
+    },
+    {
+        "en": "Puerto Rico"
+    },
+    {
+        "en": "Qatar"
+    },
+    {
+        "en": "Réunion"
+    },
+    {
+        "en": "Romania"
+    },
+    {
+        "en": "Russia"
+    },
+    {
+        "en": "Rwanda"
+    },
+    {
+        "en": "Saint Martin (French part)"
+    },
+    {
+        "en": "Samoa"
+    },
+    {
+        "en": "San Marino"
+    },
+    {
+        "en": "São Tomé and Príncipe"
+    },
+    {
+        "en": "Saudi Arabia"
+    },
+    {
+        "en": "Senegal"
+    },
+    {
+        "en": "Serbia"
+    },
+    {
+        "en": "Seychelles"
+    },
+    {
+        "en": "Sierra Leone"
+    },
+    {
+        "en": "Singapore"
+    },
+    {
+        "en": "Sint Maarten (Dutch Part)"
+    },
+    {
+        "en": "Slovakia"
+    },
+    {
+        "en": "Slovenia"
+    },
+    {
+        "en": "Solomon Islands"
+    },
+    {
+        "en": "Somalia"
+    },
+    {
+        "en": "South Africa"
+    },
+    {
+        "en": "South Georgia and the South Sandwich Islands"
+    },
+    {
+        "en": "South Korea"
+    },
+    {
+        "en": "South Sudan"
+    },
+    {
+        "en": "Spain (including Balearic Islands)"
+    },
+    {
+        "en": "Sri Lanka"
+    },
+    {
+        "en": "St Barthélemy"
+    },
+    {
+        "en": "St Helena, Ascension and Tristan da Cunha"
+    },
+    {
+        "en": "St Kitts and Nevis"
+    },
+    {
+        "en": "St Lucia"
+    },
+    {
+        "en": "St Pierre and Miquelon"
+    },
+    {
+        "en": "St Vincent and the Grenadines"
+    },
+    {
+        "en": "Sudan"
+    },
+    {
+        "en": "Suriname"
+    },
+    {
+        "en": "Svalbard and Jan Mayen"
+    },
+    {
+        "en": "Sweden"
+    },
+    {
+        "en": "Switzerland"
+    },
+    {
+        "en": "Syria"
+    },
+    {
+        "en": "Taiwan"
+    },
+    {
+        "en": "Tajikistan"
+    },
+    {
+        "en": "Tanzania"
+    },
+    {
+        "en": "Thailand"
+    },
+    {
+        "en": "The Bahamas"
+    },
+    {
+        "en": "The Gambia"
+    },
+    {
+        "en": "Togo"
+    },
+    {
+        "en": "Tokelau"
+    },
+    {
+        "en": "Tonga"
+    },
+    {
+        "en": "Trinidad and Tobago"
+    },
+    {
+        "en": "Tunisia"
+    },
+    {
+        "en": "Turkey"
+    },
+    {
+        "en": "Turkmenistan"
+    },
+    {
+        "en": "Turks and Caicos Islands"
+    },
+    {
+        "en": "Tuvalu"
+    },
+    {
+        "en": "Uganda"
+    },
+    {
+        "en": "Ukraine"
+    },
+    {
+        "en": "United Arab Emirates"
+    },
+    {
+        "en": "United States minor outlying islands"
+    },
+    {
+        "en": "United States of America"
+    },
+    {
+        "en": "United States Virgin Islands"
+    },
+    {
+        "en": "Uruguay"
+    },
+    {
+        "en": "Uzbekistan"
+    },
+    {
+        "en": "Vanuatu"
+    },
+    {
+        "en": "Vatican City"
+    },
+    {
+        "en": "Venezuela"
+    },
+    {
+        "en": "Vietnam"
+    },
+    {
+        "en": "Wallis and Futuna"
+    },
+    {
+        "en": "Western Sahara"
+    },
+    {
+        "en": "Yemen"
+    },
+    {
+        "en": "Zambia"
+    },
+    {
+        "en": "Zimbabwe"
+    }
 ]

--- a/data/gb/en/ethnic-groups.json
+++ b/data/gb/en/ethnic-groups.json
@@ -1,183 +1,545 @@
 [
-    "Afghan",
-    "African",
-    "African American",
-    "African Asian",
-    "African Caribbean",
-    "Albanian",
-    "Algerian",
-    "American",
-    "Anglo Indian",
-    "Anglo Irish",
-    "Anglo Italian",
-    "Anglo Saxon",
-    "Arab",
-    "Argentinian",
-    "Armenian",
-    "Asian",
-    "Asian British",
-    "Asian English",
-    "Asian Northern Irish",
-    "Asian Scottish",
-    "Asian Welsh",
-    "Assyrian",
-    "Australian",
-    "Austrian",
-    "Baltic",
-    "Bangladeshi",
-    "Belarusian",
-    "Belgian",
-    "Berber",
-    "Black African",
-    "Black British",
-    "Black Caribbean",
-    "Black English",
-    "Black Northern Irish",
-    "Black Scottish",
-    "Black Welsh",
-    "Bosnian",
-    "Brazilian",
-    "British",
-    "British Indian",
-    "British Pakistani",
-    "Bulgarian",
-    "Burmese or Myanma",
-    "Cambodian",
-    "Canadian",
-    "Caribbean",
-    "Celtic",
-    "Central European",
-    "Chilean",
-    "Chinese",
-    "Colombian",
-    "Congolese",
-    "Cornish",
-    "Croatian",
-    "Cypriot",
-    "Czech",
-    "Danish",
-    "Dutch",
-    "East African",
-    "Eastern European",
-    "Eelam Tamil",
-    "Eritrean",
-    "Ethiopian",
-    "Egyptian",
-    "English",
-    "Estonian",
-    "Eurasian",
-    "European",
-    "Fijian",
-    "Filipina",
-    "Filipino",
-    "Finnish",
-    "French",
-    "Georgian",
-    "German",
-    "Ghanaian",
-    "Goan",
-    "Greek",
-    "Greek Cypriot",
-    "Gurkha",
-    "Guyanese",
-    "Gypsy",
-    "Hellenic",
-    "Hispanic",
-    "Hungarian",
-    "Icelandic",
-    "Indian",
-    "Indonesian",
-    "Iranian",
-    "Iraqi",
-    "Irish",
-    "Irish Traveller",
-    "Israeli",
-    "Italian",
-    "Jamaican",
-    "Japanese",
-    "Jewish",
-    "Kashmiri",
-    "Kazakh",
-    "Kenyan",
-    "Korean",
-    "Kosovan",
-    "Kurdish",
-    "Latin American",
-    "Latino",
-    "Latvian",
-    "Lebanese",
-    "Lithuanian",
-    "Macedonian",
-    "Malay",
-    "Malaysian",
-    "Maltese",
-    "Manx",
-    "Mauritian",
-    "Mediterranean",
-    "Mexican",
-    "Middle Eastern",
-    "Mongolian",
-    "Moroccan",
-    "Nepali",
-    "New Zealander",
-    "Nigerian (Nigeria)",
-    "Nigerien (Niger)",
-    "Nordic",
-    "North African",
-    "North American",
-    "Northern European",
-    "Northern Irish",
-    "Norwegian",
-    "Pakistani",
-    "Persian",
-    "Philippine",
-    "Polish",
-    "Portuguese",
-    "Punjabi",
-    "Roma",
-    "Romanian",
-    "Russian",
-    "São Toméan",
-    "Scandinavian",
-    "Scottish",
-    "Serbian",
-    "Showman",
-    "Showperson",
-    "Showwoman",
-    "Sikh",
-    "Sinhalese",
-    "Slavic",
-    "Slovakian",
-    "Slovenian",
-    "Somali",
-    "Somalilander",
-    "South African",
-    "South American",
-    "South East Asian",
-    "South Korean",
-    "Spanish",
-    "Sri Lankan",
-    "Swedish",
-    "Swiss",
-    "Taiwanese",
-    "Tamil",
-    "Tamil Eelam",
-    "Thai",
-    "Turkish",
-    "Turkish Cypriot",
-    "Ugandan",
-    "Ukrainian",
-    "Vietnamese",
-    "Welsh",
-    "Western European",
-    "White African",
-    "White British",
-    "White Caribbean",
-    "White English",
-    "White Northern Irish",
-    "White Scottish",
-    "White Welsh",
-    "Yemeni",
-    "Yorkshire",
-    "Zimbabwean"
+    {
+        "en": "Afghan"
+    },
+    {
+        "en": "African"
+    },
+    {
+        "en": "African American"
+    },
+    {
+        "en": "African Asian"
+    },
+    {
+        "en": "African Caribbean"
+    },
+    {
+        "en": "Albanian"
+    },
+    {
+        "en": "Algerian"
+    },
+    {
+        "en": "American"
+    },
+    {
+        "en": "Anglo Indian"
+    },
+    {
+        "en": "Anglo Irish"
+    },
+    {
+        "en": "Anglo Italian"
+    },
+    {
+        "en": "Anglo Saxon"
+    },
+    {
+        "en": "Arab"
+    },
+    {
+        "en": "Argentinian"
+    },
+    {
+        "en": "Armenian"
+    },
+    {
+        "en": "Asian"
+    },
+    {
+        "en": "Asian British"
+    },
+    {
+        "en": "Asian English"
+    },
+    {
+        "en": "Asian Northern Irish"
+    },
+    {
+        "en": "Asian Scottish"
+    },
+    {
+        "en": "Asian Welsh"
+    },
+    {
+        "en": "Assyrian"
+    },
+    {
+        "en": "Australian"
+    },
+    {
+        "en": "Austrian"
+    },
+    {
+        "en": "Baltic"
+    },
+    {
+        "en": "Bangladeshi"
+    },
+    {
+        "en": "Belarusian"
+    },
+    {
+        "en": "Belgian"
+    },
+    {
+        "en": "Berber"
+    },
+    {
+        "en": "Black African"
+    },
+    {
+        "en": "Black British"
+    },
+    {
+        "en": "Black Caribbean"
+    },
+    {
+        "en": "Black English"
+    },
+    {
+        "en": "Black Northern Irish"
+    },
+    {
+        "en": "Black Scottish"
+    },
+    {
+        "en": "Black Welsh"
+    },
+    {
+        "en": "Bosnian"
+    },
+    {
+        "en": "Brazilian"
+    },
+    {
+        "en": "British"
+    },
+    {
+        "en": "British Indian"
+    },
+    {
+        "en": "British Pakistani"
+    },
+    {
+        "en": "Bulgarian"
+    },
+    {
+        "en": "Burmese or Myanma"
+    },
+    {
+        "en": "Cambodian"
+    },
+    {
+        "en": "Canadian"
+    },
+    {
+        "en": "Caribbean"
+    },
+    {
+        "en": "Celtic"
+    },
+    {
+        "en": "Central European"
+    },
+    {
+        "en": "Chilean"
+    },
+    {
+        "en": "Chinese"
+    },
+    {
+        "en": "Colombian"
+    },
+    {
+        "en": "Congolese"
+    },
+    {
+        "en": "Cornish"
+    },
+    {
+        "en": "Croatian"
+    },
+    {
+        "en": "Cypriot"
+    },
+    {
+        "en": "Czech"
+    },
+    {
+        "en": "Danish"
+    },
+    {
+        "en": "Dutch"
+    },
+    {
+        "en": "East African"
+    },
+    {
+        "en": "Eastern European"
+    },
+    {
+        "en": "Eelam Tamil"
+    },
+    {
+        "en": "Eritrean"
+    },
+    {
+        "en": "Ethiopian"
+    },
+    {
+        "en": "Egyptian"
+    },
+    {
+        "en": "English"
+    },
+    {
+        "en": "Estonian"
+    },
+    {
+        "en": "Eurasian"
+    },
+    {
+        "en": "European"
+    },
+    {
+        "en": "Fijian"
+    },
+    {
+        "en": "Filipina"
+    },
+    {
+        "en": "Filipino"
+    },
+    {
+        "en": "Finnish"
+    },
+    {
+        "en": "French"
+    },
+    {
+        "en": "Georgian"
+    },
+    {
+        "en": "German"
+    },
+    {
+        "en": "Ghanaian"
+    },
+    {
+        "en": "Goan"
+    },
+    {
+        "en": "Greek"
+    },
+    {
+        "en": "Greek Cypriot"
+    },
+    {
+        "en": "Gurkha"
+    },
+    {
+        "en": "Guyanese"
+    },
+    {
+        "en": "Gypsy"
+    },
+    {
+        "en": "Hellenic"
+    },
+    {
+        "en": "Hispanic"
+    },
+    {
+        "en": "Hungarian"
+    },
+    {
+        "en": "Icelandic"
+    },
+    {
+        "en": "Indian"
+    },
+    {
+        "en": "Indonesian"
+    },
+    {
+        "en": "Iranian"
+    },
+    {
+        "en": "Iraqi"
+    },
+    {
+        "en": "Irish"
+    },
+    {
+        "en": "Irish Traveller"
+    },
+    {
+        "en": "Israeli"
+    },
+    {
+        "en": "Italian"
+    },
+    {
+        "en": "Jamaican"
+    },
+    {
+        "en": "Japanese"
+    },
+    {
+        "en": "Jewish"
+    },
+    {
+        "en": "Kashmiri"
+    },
+    {
+        "en": "Kazakh"
+    },
+    {
+        "en": "Kenyan"
+    },
+    {
+        "en": "Korean"
+    },
+    {
+        "en": "Kosovan"
+    },
+    {
+        "en": "Kurdish"
+    },
+    {
+        "en": "Latin American"
+    },
+    {
+        "en": "Latino"
+    },
+    {
+        "en": "Latvian"
+    },
+    {
+        "en": "Lebanese"
+    },
+    {
+        "en": "Lithuanian"
+    },
+    {
+        "en": "Macedonian"
+    },
+    {
+        "en": "Malay"
+    },
+    {
+        "en": "Malaysian"
+    },
+    {
+        "en": "Maltese"
+    },
+    {
+        "en": "Manx"
+    },
+    {
+        "en": "Mauritian"
+    },
+    {
+        "en": "Mediterranean"
+    },
+    {
+        "en": "Mexican"
+    },
+    {
+        "en": "Middle Eastern"
+    },
+    {
+        "en": "Mongolian"
+    },
+    {
+        "en": "Moroccan"
+    },
+    {
+        "en": "Nepali"
+    },
+    {
+        "en": "New Zealander"
+    },
+    {
+        "en": "Nigerian (Nigeria)"
+    },
+    {
+        "en": "Nigerien (Niger)"
+    },
+    {
+        "en": "Nordic"
+    },
+    {
+        "en": "North African"
+    },
+    {
+        "en": "North American"
+    },
+    {
+        "en": "Northern European"
+    },
+    {
+        "en": "Northern Irish"
+    },
+    {
+        "en": "Norwegian"
+    },
+    {
+        "en": "Pakistani"
+    },
+    {
+        "en": "Persian"
+    },
+    {
+        "en": "Philippine"
+    },
+    {
+        "en": "Polish"
+    },
+    {
+        "en": "Portuguese"
+    },
+    {
+        "en": "Punjabi"
+    },
+    {
+        "en": "Roma"
+    },
+    {
+        "en": "Romanian"
+    },
+    {
+        "en": "Russian"
+    },
+    {
+        "en": "São Toméan"
+    },
+    {
+        "en": "Scandinavian"
+    },
+    {
+        "en": "Scottish"
+    },
+    {
+        "en": "Serbian"
+    },
+    {
+        "en": "Showman"
+    },
+    {
+        "en": "Showperson"
+    },
+    {
+        "en": "Showwoman"
+    },
+    {
+        "en": "Sikh"
+    },
+    {
+        "en": "Sinhalese"
+    },
+    {
+        "en": "Slavic"
+    },
+    {
+        "en": "Slovakian"
+    },
+    {
+        "en": "Slovenian"
+    },
+    {
+        "en": "Somali"
+    },
+    {
+        "en": "Somalilander"
+    },
+    {
+        "en": "South African"
+    },
+    {
+        "en": "South American"
+    },
+    {
+        "en": "South East Asian"
+    },
+    {
+        "en": "South Korean"
+    },
+    {
+        "en": "Spanish"
+    },
+    {
+        "en": "Sri Lankan"
+    },
+    {
+        "en": "Swedish"
+    },
+    {
+        "en": "Swiss"
+    },
+    {
+        "en": "Taiwanese"
+    },
+    {
+        "en": "Tamil"
+    },
+    {
+        "en": "Tamil Eelam"
+    },
+    {
+        "en": "Thai"
+    },
+    {
+        "en": "Turkish"
+    },
+    {
+        "en": "Turkish Cypriot"
+    },
+    {
+        "en": "Ugandan"
+    },
+    {
+        "en": "Ukrainian"
+    },
+    {
+        "en": "Vietnamese"
+    },
+    {
+        "en": "Welsh"
+    },
+    {
+        "en": "Western European"
+    },
+    {
+        "en": "White African"
+    },
+    {
+        "en": "White British"
+    },
+    {
+        "en": "White Caribbean"
+    },
+    {
+        "en": "White English"
+    },
+    {
+        "en": "White Northern Irish"
+    },
+    {
+        "en": "White Scottish"
+    },
+    {
+        "en": "White Welsh"
+    },
+    {
+        "en": "Yemeni"
+    },
+    {
+        "en": "Yorkshire"
+    },
+    {
+        "en": "Zimbabwean"
+    }
 ]

--- a/data/gb/en/languages.json
+++ b/data/gb/en/languages.json
@@ -1,177 +1,527 @@
 [
-    "Abkhazian",
-    "Afar",
-    "Afrikaans",
-    "Albanian",
-    "Amharic",
-    "Arabic",
-    "Aragonese",
-    "Armenian",
-    "Assamese",
-    "Aymara",
-    "Azerbaijani",
-    "Bambara",
-    "Bashkir",
-    "Basque",
-    "Belarusian",
-    "Bengali or Bangla",
-    "Bihari languages",
-    "Bislama",
-    "Bosnian",
-    "Breton",
-    "British Sign Language",
-    "Bulgarian",
-    "Burmese",
-    "Cantonese",
-    "Castilian",
-    "Catalan",
-    "Chechen",
-    "Chewa",
-    "Chichewa",
-    "Chinese",
-    "Chuvash",
-    "Cornish",
-    "Cree",
-    "Croatian",
-    "Cymraeg",
-    "Czech",
-    "Danish",
-    "Dari",
-    "Dhivehi",
-    "Dutch",
-    "Dzongkha",
-    "English",
-    "Estonian",
-    "Ewe",
-    "Faroese",
-    "Fijian",
-    "Filipino",
-    "Finnish",
-    "Flemish",
-    "French",
-    "Fulah",
-    "Gaelic",
-    "Ganda",
-    "Georgian",
-    "German",
-    "Gikuyu",
-    "Greek",
-    "Greenlandic",
-    "Guarani",
-    "Gujarati",
-    "Haitian",
-    "Haitian Creole",
-    "Hausa",
-    "Hebrew",
-    "Herero",
-    "Hindi",
-    "Hungarian",
-    "Icelandic",
-    "Igbo",
-    "Indonesian",
-    "Irish",
-    "Italian",
-    "Japanese",
-    "Javanese",
-    "Kannada",
-    "Kanuri",
-    "Kashmiri",
-    "Kazakh",
-    "Kikuyu",
-    "Kinyarwanda",
-    "Komi",
-    "Korean",
-    "Kurdish",
-    "Kwanyama",
-    "Kyrgyz",
-    "Lao",
-    "Latvian",
-    "Letzeburgesch",
-    "Lingala",
-    "Lithuanian",
-    "Luxembourgish",
-    "Macedonian",
-    "Malagasy",
-    "Malay",
-    "Malayalam",
-    "Maldivian",
-    "Maltese",
-    "Mandarin",
-    "Manx",
-    "Maori",
-    "Marathi",
-    "Mirpuri",
-    "Moldavian",
-    "Moldovan",
-    "Mongolian",
-    "Navajo",
-    "Nepali",
-    "North Ndebele",
-    "Norwegian",
-    "Norwegian Bokmål",
-    "Norwegian Nynorsk",
-    "Nyanja",
-    "Oriya",
-    "Oromo",
-    "Panjabi",
-    "Pashto",
-    "Persian or Farsi",
-    "Polish",
-    "Portuguese",
-    "Punjabi",
-    "Pushto",
-    "Quechua",
-    "Romanian",
-    "Romansh",
-    "Rundi",
-    "Russian",
-    "Samoan",
-    "Sango",
-    "Scottish Gaelic",
-    "Serbian",
-    "Shona",
-    "Sindhi",
-    "Sinhala",
-    "Sinhalese",
-    "Slovak",
-    "Slovenian",
-    "Somali",
-    "Southern Sotho",
-    "South Ndebele",
-    "Spanish",
-    "Sundanese",
-    "Swahili",
-    "Swati",
-    "Swedish",
-    "Sylheti",
-    "Tagalog",
-    "Tahitian",
-    "Tajik",
-    "Tamil",
-    "Tatar",
-    "Telugu",
-    "Thai",
-    "Tibetan",
-    "Tigrinya",
-    "Tonga (Tonga Islands)",
-    "Tsonga",
-    "Tswana",
-    "Turkish",
-    "Turkmen",
-    "Twi",
-    "Uighur",
-    "Ukrainian",
-    "Urdu",
-    "Uyghur",
-    "Uzbek",
-    "Venda",
-    "Vietnamese",
-    "Walloon",
-    "Welsh",
-    "Wolof",
-    "Xhosa",
-    "Yiddish",
-    "Yoruba",
-    "Zhuang",
-    "Zulu"
+    {
+        "en": "Abkhazian"
+    },
+    {
+        "en": "Afar"
+    },
+    {
+        "en": "Afrikaans"
+    },
+    {
+        "en": "Albanian"
+    },
+    {
+        "en": "Amharic"
+    },
+    {
+        "en": "Arabic"
+    },
+    {
+        "en": "Aragonese"
+    },
+    {
+        "en": "Armenian"
+    },
+    {
+        "en": "Assamese"
+    },
+    {
+        "en": "Aymara"
+    },
+    {
+        "en": "Azerbaijani"
+    },
+    {
+        "en": "Bambara"
+    },
+    {
+        "en": "Bashkir"
+    },
+    {
+        "en": "Basque"
+    },
+    {
+        "en": "Belarusian"
+    },
+    {
+        "en": "Bengali or Bangla"
+    },
+    {
+        "en": "Bihari languages"
+    },
+    {
+        "en": "Bislama"
+    },
+    {
+        "en": "Bosnian"
+    },
+    {
+        "en": "Breton"
+    },
+    {
+        "en": "British Sign Language"
+    },
+    {
+        "en": "Bulgarian"
+    },
+    {
+        "en": "Burmese"
+    },
+    {
+        "en": "Cantonese"
+    },
+    {
+        "en": "Castilian"
+    },
+    {
+        "en": "Catalan"
+    },
+    {
+        "en": "Chechen"
+    },
+    {
+        "en": "Chewa"
+    },
+    {
+        "en": "Chichewa"
+    },
+    {
+        "en": "Chinese"
+    },
+    {
+        "en": "Chuvash"
+    },
+    {
+        "en": "Cornish"
+    },
+    {
+        "en": "Cree"
+    },
+    {
+        "en": "Croatian"
+    },
+    {
+        "en": "Cymraeg"
+    },
+    {
+        "en": "Czech"
+    },
+    {
+        "en": "Danish"
+    },
+    {
+        "en": "Dari"
+    },
+    {
+        "en": "Dhivehi"
+    },
+    {
+        "en": "Dutch"
+    },
+    {
+        "en": "Dzongkha"
+    },
+    {
+        "en": "English"
+    },
+    {
+        "en": "Estonian"
+    },
+    {
+        "en": "Ewe"
+    },
+    {
+        "en": "Faroese"
+    },
+    {
+        "en": "Fijian"
+    },
+    {
+        "en": "Filipino"
+    },
+    {
+        "en": "Finnish"
+    },
+    {
+        "en": "Flemish"
+    },
+    {
+        "en": "French"
+    },
+    {
+        "en": "Fulah"
+    },
+    {
+        "en": "Gaelic"
+    },
+    {
+        "en": "Ganda"
+    },
+    {
+        "en": "Georgian"
+    },
+    {
+        "en": "German"
+    },
+    {
+        "en": "Gikuyu"
+    },
+    {
+        "en": "Greek"
+    },
+    {
+        "en": "Greenlandic"
+    },
+    {
+        "en": "Guarani"
+    },
+    {
+        "en": "Gujarati"
+    },
+    {
+        "en": "Haitian"
+    },
+    {
+        "en": "Haitian Creole"
+    },
+    {
+        "en": "Hausa"
+    },
+    {
+        "en": "Hebrew"
+    },
+    {
+        "en": "Herero"
+    },
+    {
+        "en": "Hindi"
+    },
+    {
+        "en": "Hungarian"
+    },
+    {
+        "en": "Icelandic"
+    },
+    {
+        "en": "Igbo"
+    },
+    {
+        "en": "Indonesian"
+    },
+    {
+        "en": "Irish"
+    },
+    {
+        "en": "Italian"
+    },
+    {
+        "en": "Japanese"
+    },
+    {
+        "en": "Javanese"
+    },
+    {
+        "en": "Kannada"
+    },
+    {
+        "en": "Kanuri"
+    },
+    {
+        "en": "Kashmiri"
+    },
+    {
+        "en": "Kazakh"
+    },
+    {
+        "en": "Kikuyu"
+    },
+    {
+        "en": "Kinyarwanda"
+    },
+    {
+        "en": "Komi"
+    },
+    {
+        "en": "Korean"
+    },
+    {
+        "en": "Kurdish"
+    },
+    {
+        "en": "Kwanyama"
+    },
+    {
+        "en": "Kyrgyz"
+    },
+    {
+        "en": "Lao"
+    },
+    {
+        "en": "Latvian"
+    },
+    {
+        "en": "Letzeburgesch"
+    },
+    {
+        "en": "Lingala"
+    },
+    {
+        "en": "Lithuanian"
+    },
+    {
+        "en": "Luxembourgish"
+    },
+    {
+        "en": "Macedonian"
+    },
+    {
+        "en": "Malagasy"
+    },
+    {
+        "en": "Malay"
+    },
+    {
+        "en": "Malayalam"
+    },
+    {
+        "en": "Maldivian"
+    },
+    {
+        "en": "Maltese"
+    },
+    {
+        "en": "Mandarin"
+    },
+    {
+        "en": "Manx"
+    },
+    {
+        "en": "Maori"
+    },
+    {
+        "en": "Marathi"
+    },
+    {
+        "en": "Mirpuri"
+    },
+    {
+        "en": "Moldavian"
+    },
+    {
+        "en": "Moldovan"
+    },
+    {
+        "en": "Mongolian"
+    },
+    {
+        "en": "Navajo"
+    },
+    {
+        "en": "Nepali"
+    },
+    {
+        "en": "North Ndebele"
+    },
+    {
+        "en": "Norwegian"
+    },
+    {
+        "en": "Norwegian Bokmål"
+    },
+    {
+        "en": "Norwegian Nynorsk"
+    },
+    {
+        "en": "Nyanja"
+    },
+    {
+        "en": "Oriya"
+    },
+    {
+        "en": "Oromo"
+    },
+    {
+        "en": "Panjabi"
+    },
+    {
+        "en": "Pashto"
+    },
+    {
+        "en": "Persian or Farsi"
+    },
+    {
+        "en": "Polish"
+    },
+    {
+        "en": "Portuguese"
+    },
+    {
+        "en": "Punjabi"
+    },
+    {
+        "en": "Pushto"
+    },
+    {
+        "en": "Quechua"
+    },
+    {
+        "en": "Romanian"
+    },
+    {
+        "en": "Romansh"
+    },
+    {
+        "en": "Rundi"
+    },
+    {
+        "en": "Russian"
+    },
+    {
+        "en": "Samoan"
+    },
+    {
+        "en": "Sango"
+    },
+    {
+        "en": "Scottish Gaelic"
+    },
+    {
+        "en": "Serbian"
+    },
+    {
+        "en": "Shona"
+    },
+    {
+        "en": "Sindhi"
+    },
+    {
+        "en": "Sinhala"
+    },
+    {
+        "en": "Sinhalese"
+    },
+    {
+        "en": "Slovak"
+    },
+    {
+        "en": "Slovenian"
+    },
+    {
+        "en": "Somali"
+    },
+    {
+        "en": "Southern Sotho"
+    },
+    {
+        "en": "South Ndebele"
+    },
+    {
+        "en": "Spanish"
+    },
+    {
+        "en": "Sundanese"
+    },
+    {
+        "en": "Swahili"
+    },
+    {
+        "en": "Swati"
+    },
+    {
+        "en": "Swedish"
+    },
+    {
+        "en": "Sylheti"
+    },
+    {
+        "en": "Tagalog"
+    },
+    {
+        "en": "Tahitian"
+    },
+    {
+        "en": "Tajik"
+    },
+    {
+        "en": "Tamil"
+    },
+    {
+        "en": "Tatar"
+    },
+    {
+        "en": "Telugu"
+    },
+    {
+        "en": "Thai"
+    },
+    {
+        "en": "Tibetan"
+    },
+    {
+        "en": "Tigrinya"
+    },
+    {
+        "en": "Tonga (Tonga Islands)"
+    },
+    {
+        "en": "Tsonga"
+    },
+    {
+        "en": "Tswana"
+    },
+    {
+        "en": "Turkish"
+    },
+    {
+        "en": "Turkmen"
+    },
+    {
+        "en": "Twi"
+    },
+    {
+        "en": "Uighur"
+    },
+    {
+        "en": "Ukrainian"
+    },
+    {
+        "en": "Urdu"
+    },
+    {
+        "en": "Uyghur"
+    },
+    {
+        "en": "Uzbek"
+    },
+    {
+        "en": "Venda"
+    },
+    {
+        "en": "Vietnamese"
+    },
+    {
+        "en": "Walloon"
+    },
+    {
+        "en": "Welsh"
+    },
+    {
+        "en": "Wolof"
+    },
+    {
+        "en": "Xhosa"
+    },
+    {
+        "en": "Yiddish"
+    },
+    {
+        "en": "Yoruba"
+    },
+    {
+        "en": "Zhuang"
+    },
+    {
+        "en": "Zulu"
+    }
 ]

--- a/data/gb/en/national-identities.json
+++ b/data/gb/en/national-identities.json
@@ -1,281 +1,839 @@
 [
-    "Afghan",
-    "African",
-    "Ålandic",
-    "Albanian",
-    "Algerian",
-    "American",
-    "American Islander",
-    "American Samoan",
-    "Andorran",
-    "Angolan",
-    "Anguillian",
-    "Antiguan",
-    "Argentinian",
-    "Armenian",
-    "Aruban",
-    "Asian",
-    "Australian",
-    "Austrian",
-    "Azerbaijani",
-    "Bahamian",
-    "Bahraini",
-    "Bangladeshi",
-    "Barbadian",
-    "Barbudan",
-    "Barthélemois",
-    "Batswana",
-    "Belarusian",
-    "Belgian",
-    "Belizean",
-    "Beninese",
-    "Bermudian",
-    "Bhutanese",
-    "Bissau-Guinean",
-    "Bolivian",
-    "Bonairean",
-    "Statian",
-    "Sabian",
-    "Bosnian",
-    "Brazilian",
-    "British",
-    "Bruneian",
-    "Bulgarian",
-    "Burkinese",
-    "Burmese",
-    "Burundian",
-    "Cambodian",
-    "Cameroonian",
-    "Canadian",
-    "Canarian",
-    "Cape Verdean",
-    "Caymanian",
-    "Central African",
-    "Chadian",
-    "Chagos Islander",
-    "Channel Islander",
-    "Chilean",
-    "Chinese",
-    "Christmas Islander",
-    "Cocos Islander",
-    "Colombian",
-    "Comorian",
-    "Congolese (Democratic Republic of Congo)",
-    "Congolese (Republic of Congo)",
-    "Cook Islander",
-    "Cornish",
-    "Costa Rican",
-    "Croatian",
-    "Cuban",
-    "Curaçaoan",
-    "Cypriot",
-    "Czech",
-    "Danish",
-    "Djiboutian",
-    "Dominican (Dominica)",
-    "Dominican (Dominican Republic)",
-    "Dutch",
-    "East Timorese",
-    "Ecuadorian",
-    "Egyptian",
-    "Emirati",
-    "English",
-    "Equatoguinean",
-    "Equatorial Guinean",
-    "Eritrean",
-    "Estonian",
-    "Ethiopian",
-    "European",
-    "Falkland Islander",
-    "Faroese",
-    "Fijian",
-    "Filipina",
-    "Filipino",
-    "Finnish",
-    "French",
-    "French Polynesian",
-    "Futunan",
-    "Gabonese",
-    "Gambian",
-    "Georgian",
-    "German",
-    "Ghanaian",
-    "Gibraltarian",
-    "Greek",
-    "Greek Cypriot",
-    "Greenlandic",
-    "Grenadian",
-    "Guadeloupean",
-    "Guamanian",
-    "Guatemalan",
-    "Guianan",
-    "Guinean (Guinea)",
-    "Guinean (Guinea-Bissau)",
-    "Guyanese",
-    "Haitian",
-    "Honduran",
-    "HongKonger",
-    "Hong Kong Chinese",
-    "Hungarian",
-    "Icelandic",
-    "I-Kiribati",
-    "Indian",
-    "Indonesian",
-    "Iranian",
-    "Iraqi",
-    "Irish",
-    "Israeli",
-    "Italian",
-    "Ivorian",
-    "Jamaican",
-    "Japanese",
-    "Jordanian",
-    "Kazakhstani",
-    "Kenyan",
-    "Kernewek",
-    "Kernouak",
-    "Kernowyon",
-    "Kernowek",
-    "Kittitian",
-    "Korean",
-    "Kosovan",
-    "Kurdish",
-    "Kuwaiti",
-    "Kyrgyz",
-    "Lao",
-    "Latvian",
-    "Lebanese",
-    "Lesothan",
-    "Liberian",
-    "Libyan",
-    "Liechtensteiner",
-    "Lithuanian",
-    "Luxembourger",
-    "Macau",
-    "Macedonian",
-    "Madagascan",
-    "Malawian",
-    "Malaysian",
-    "Maldivian",
-    "Malian",
-    "Maltese",
-    "Manx",
-    "Maori",
-    "Marshallese",
-    "Martiniquan",
-    "Mauritanian",
-    "Mauritian",
-    "Mexican",
-    "Micronesian",
-    "Miquelonnais",
-    "Moldovan",
-    "Monacan",
-    "Mongolian",
-    "Montenegrin",
-    "Montserratian",
-    "Moroccan",
-    "Motswana",
-    "Mozambican",
-    "Myanma",
-    "Namibian",
-    "Nauruan",
-    "Nepali",
-    "Nevisian",
-    "New Caledonian",
-    "New Zealander",
-    "Nicaraguan",
-    "Nigerian (Nigeria)",
-    "Nigerien (Niger)",
-    "Niuean",
-    "Ni-Vanuatu",
-    "Norfolk Islander",
-    "North Korean",
-    "Northern Irish",
-    "Northern Mariana Islander",
-    "Norwegian",
-    "Omani",
-    "Pakistani",
-    "Palauan",
-    "Palestinian",
-    "Panamanian",
-    "Papua New Guinean",
-    "Paraguayan",
-    "Peruvian",
-    "Pitcairn Islander",
-    "Polish",
-    "Portuguese",
-    "Puerto Rican",
-    "Qatari",
-    "Quisqueyan",
-    "Réunionese",
-    "Romanian",
-    "Russian",
-    "Rwandan",
-    "Sahrawi",
-    "Saint Helenian",
-    "Saint Maartener",
-    "Saint Vincentian",
-    "Saint-Martinois",
-    "Saint-Pierrais",
-    "Salvadoran",
-    "Sammarinese",
-    "Samoan",
-    "São Toméan",
-    "Saudi Arabian",
-    "Scottish",
-    "Senegalese",
-    "Serbian",
-    "Seychellois",
-    "Sierra Leonean",
-    "Singaporean",
-    "Slovakian",
-    "Slovenian",
-    "Solomon Islander",
-    "Somali",
-    "South African",
-    "South Georgian",
-    "South Korean",
-    "South Sandwich Islander",
-    "South Sudanese",
-    "Spanish",
-    "Sri Lankan",
-    "St Helenian",
-    "Saint Lucian",
-    "St Lucian",
-    "St Maartener",
-    "St Vincentian",
-    "Sudanese",
-    "Surinamese",
-    "Svalbard and Jan Mayen Islander",
-    "Swazi",
-    "Swedish",
-    "Swiss",
-    "Syrian",
-    "Taiwanese",
-    "Tajik",
-    "Tanzanian",
-    "Thai",
-    "Togolese",
-    "Tokelauan",
-    "Tongan",
-    "Trinidadian and Tobagonian",
-    "Tunisian",
-    "Turkish",
-    "Turkish Cypriot",
-    "Turkmenistani",
-    "Turks and Caicos Islander",
-    "Tuvaluan",
-    "Ugandan",
-    "Ukrainian",
-    "Uruguayan",
-    "Uzbek",
-    "Venezuelan",
-    "Vietnamese",
-    "Vincentian",
-    "Virgin Islander",
-    "Wallisian",
-    "Welsh",
-    "Yemeni",
-    "Zambian",
-    "Zimbabwean"
+    {
+        "en": "Afghan"
+    },
+    {
+        "en": "African"
+    },
+    {
+        "en": "Ålandic"
+    },
+    {
+        "en": "Albanian"
+    },
+    {
+        "en": "Algerian"
+    },
+    {
+        "en": "American"
+    },
+    {
+        "en": "American Islander"
+    },
+    {
+        "en": "American Samoan"
+    },
+    {
+        "en": "Andorran"
+    },
+    {
+        "en": "Angolan"
+    },
+    {
+        "en": "Anguillian"
+    },
+    {
+        "en": "Antiguan"
+    },
+    {
+        "en": "Argentinian"
+    },
+    {
+        "en": "Armenian"
+    },
+    {
+        "en": "Aruban"
+    },
+    {
+        "en": "Asian"
+    },
+    {
+        "en": "Australian"
+    },
+    {
+        "en": "Austrian"
+    },
+    {
+        "en": "Azerbaijani"
+    },
+    {
+        "en": "Bahamian"
+    },
+    {
+        "en": "Bahraini"
+    },
+    {
+        "en": "Bangladeshi"
+    },
+    {
+        "en": "Barbadian"
+    },
+    {
+        "en": "Barbudan"
+    },
+    {
+        "en": "Barthélemois"
+    },
+    {
+        "en": "Batswana"
+    },
+    {
+        "en": "Belarusian"
+    },
+    {
+        "en": "Belgian"
+    },
+    {
+        "en": "Belizean"
+    },
+    {
+        "en": "Beninese"
+    },
+    {
+        "en": "Bermudian"
+    },
+    {
+        "en": "Bhutanese"
+    },
+    {
+        "en": "Bissau-Guinean"
+    },
+    {
+        "en": "Bolivian"
+    },
+    {
+        "en": "Bonairean"
+    },
+    {
+        "en": "Statian"
+    },
+    {
+        "en": "Sabian"
+    },
+    {
+        "en": "Bosnian"
+    },
+    {
+        "en": "Brazilian"
+    },
+    {
+        "en": "British"
+    },
+    {
+        "en": "Bruneian"
+    },
+    {
+        "en": "Bulgarian"
+    },
+    {
+        "en": "Burkinese"
+    },
+    {
+        "en": "Burmese"
+    },
+    {
+        "en": "Burundian"
+    },
+    {
+        "en": "Cambodian"
+    },
+    {
+        "en": "Cameroonian"
+    },
+    {
+        "en": "Canadian"
+    },
+    {
+        "en": "Canarian"
+    },
+    {
+        "en": "Cape Verdean"
+    },
+    {
+        "en": "Caymanian"
+    },
+    {
+        "en": "Central African"
+    },
+    {
+        "en": "Chadian"
+    },
+    {
+        "en": "Chagos Islander"
+    },
+    {
+        "en": "Channel Islander"
+    },
+    {
+        "en": "Chilean"
+    },
+    {
+        "en": "Chinese"
+    },
+    {
+        "en": "Christmas Islander"
+    },
+    {
+        "en": "Cocos Islander"
+    },
+    {
+        "en": "Colombian"
+    },
+    {
+        "en": "Comorian"
+    },
+    {
+        "en": "Congolese (Democratic Republic of Congo)"
+    },
+    {
+        "en": "Congolese (Republic of Congo)"
+    },
+    {
+        "en": "Cook Islander"
+    },
+    {
+        "en": "Cornish"
+    },
+    {
+        "en": "Costa Rican"
+    },
+    {
+        "en": "Croatian"
+    },
+    {
+        "en": "Cuban"
+    },
+    {
+        "en": "Curaçaoan"
+    },
+    {
+        "en": "Cypriot"
+    },
+    {
+        "en": "Czech"
+    },
+    {
+        "en": "Danish"
+    },
+    {
+        "en": "Djiboutian"
+    },
+    {
+        "en": "Dominican (Dominica)"
+    },
+    {
+        "en": "Dominican (Dominican Republic)"
+    },
+    {
+        "en": "Dutch"
+    },
+    {
+        "en": "East Timorese"
+    },
+    {
+        "en": "Ecuadorian"
+    },
+    {
+        "en": "Egyptian"
+    },
+    {
+        "en": "Emirati"
+    },
+    {
+        "en": "English"
+    },
+    {
+        "en": "Equatoguinean"
+    },
+    {
+        "en": "Equatorial Guinean"
+    },
+    {
+        "en": "Eritrean"
+    },
+    {
+        "en": "Estonian"
+    },
+    {
+        "en": "Ethiopian"
+    },
+    {
+        "en": "European"
+    },
+    {
+        "en": "Falkland Islander"
+    },
+    {
+        "en": "Faroese"
+    },
+    {
+        "en": "Fijian"
+    },
+    {
+        "en": "Filipina"
+    },
+    {
+        "en": "Filipino"
+    },
+    {
+        "en": "Finnish"
+    },
+    {
+        "en": "French"
+    },
+    {
+        "en": "French Polynesian"
+    },
+    {
+        "en": "Futunan"
+    },
+    {
+        "en": "Gabonese"
+    },
+    {
+        "en": "Gambian"
+    },
+    {
+        "en": "Georgian"
+    },
+    {
+        "en": "German"
+    },
+    {
+        "en": "Ghanaian"
+    },
+    {
+        "en": "Gibraltarian"
+    },
+    {
+        "en": "Greek"
+    },
+    {
+        "en": "Greek Cypriot"
+    },
+    {
+        "en": "Greenlandic"
+    },
+    {
+        "en": "Grenadian"
+    },
+    {
+        "en": "Guadeloupean"
+    },
+    {
+        "en": "Guamanian"
+    },
+    {
+        "en": "Guatemalan"
+    },
+    {
+        "en": "Guianan"
+    },
+    {
+        "en": "Guinean (Guinea)"
+    },
+    {
+        "en": "Guinean (Guinea-Bissau)"
+    },
+    {
+        "en": "Guyanese"
+    },
+    {
+        "en": "Haitian"
+    },
+    {
+        "en": "Honduran"
+    },
+    {
+        "en": "HongKonger"
+    },
+    {
+        "en": "Hong Kong Chinese"
+    },
+    {
+        "en": "Hungarian"
+    },
+    {
+        "en": "Icelandic"
+    },
+    {
+        "en": "I-Kiribati"
+    },
+    {
+        "en": "Indian"
+    },
+    {
+        "en": "Indonesian"
+    },
+    {
+        "en": "Iranian"
+    },
+    {
+        "en": "Iraqi"
+    },
+    {
+        "en": "Irish"
+    },
+    {
+        "en": "Israeli"
+    },
+    {
+        "en": "Italian"
+    },
+    {
+        "en": "Ivorian"
+    },
+    {
+        "en": "Jamaican"
+    },
+    {
+        "en": "Japanese"
+    },
+    {
+        "en": "Jordanian"
+    },
+    {
+        "en": "Kazakhstani"
+    },
+    {
+        "en": "Kenyan"
+    },
+    {
+        "en": "Kernewek"
+    },
+    {
+        "en": "Kernouak"
+    },
+    {
+        "en": "Kernowyon"
+    },
+    {
+        "en": "Kernowek"
+    },
+    {
+        "en": "Kittitian"
+    },
+    {
+        "en": "Korean"
+    },
+    {
+        "en": "Kosovan"
+    },
+    {
+        "en": "Kurdish"
+    },
+    {
+        "en": "Kuwaiti"
+    },
+    {
+        "en": "Kyrgyz"
+    },
+    {
+        "en": "Lao"
+    },
+    {
+        "en": "Latvian"
+    },
+    {
+        "en": "Lebanese"
+    },
+    {
+        "en": "Lesothan"
+    },
+    {
+        "en": "Liberian"
+    },
+    {
+        "en": "Libyan"
+    },
+    {
+        "en": "Liechtensteiner"
+    },
+    {
+        "en": "Lithuanian"
+    },
+    {
+        "en": "Luxembourger"
+    },
+    {
+        "en": "Macau"
+    },
+    {
+        "en": "Macedonian"
+    },
+    {
+        "en": "Madagascan"
+    },
+    {
+        "en": "Malawian"
+    },
+    {
+        "en": "Malaysian"
+    },
+    {
+        "en": "Maldivian"
+    },
+    {
+        "en": "Malian"
+    },
+    {
+        "en": "Maltese"
+    },
+    {
+        "en": "Manx"
+    },
+    {
+        "en": "Maori"
+    },
+    {
+        "en": "Marshallese"
+    },
+    {
+        "en": "Martiniquan"
+    },
+    {
+        "en": "Mauritanian"
+    },
+    {
+        "en": "Mauritian"
+    },
+    {
+        "en": "Mexican"
+    },
+    {
+        "en": "Micronesian"
+    },
+    {
+        "en": "Miquelonnais"
+    },
+    {
+        "en": "Moldovan"
+    },
+    {
+        "en": "Monacan"
+    },
+    {
+        "en": "Mongolian"
+    },
+    {
+        "en": "Montenegrin"
+    },
+    {
+        "en": "Montserratian"
+    },
+    {
+        "en": "Moroccan"
+    },
+    {
+        "en": "Motswana"
+    },
+    {
+        "en": "Mozambican"
+    },
+    {
+        "en": "Myanma"
+    },
+    {
+        "en": "Namibian"
+    },
+    {
+        "en": "Nauruan"
+    },
+    {
+        "en": "Nepali"
+    },
+    {
+        "en": "Nevisian"
+    },
+    {
+        "en": "New Caledonian"
+    },
+    {
+        "en": "New Zealander"
+    },
+    {
+        "en": "Nicaraguan"
+    },
+    {
+        "en": "Nigerian (Nigeria)"
+    },
+    {
+        "en": "Nigerien (Niger)"
+    },
+    {
+        "en": "Niuean"
+    },
+    {
+        "en": "Ni-Vanuatu"
+    },
+    {
+        "en": "Norfolk Islander"
+    },
+    {
+        "en": "North Korean"
+    },
+    {
+        "en": "Northern Irish"
+    },
+    {
+        "en": "Northern Mariana Islander"
+    },
+    {
+        "en": "Norwegian"
+    },
+    {
+        "en": "Omani"
+    },
+    {
+        "en": "Pakistani"
+    },
+    {
+        "en": "Palauan"
+    },
+    {
+        "en": "Palestinian"
+    },
+    {
+        "en": "Panamanian"
+    },
+    {
+        "en": "Papua New Guinean"
+    },
+    {
+        "en": "Paraguayan"
+    },
+    {
+        "en": "Peruvian"
+    },
+    {
+        "en": "Pitcairn Islander"
+    },
+    {
+        "en": "Polish"
+    },
+    {
+        "en": "Portuguese"
+    },
+    {
+        "en": "Puerto Rican"
+    },
+    {
+        "en": "Qatari"
+    },
+    {
+        "en": "Quisqueyan"
+    },
+    {
+        "en": "Réunionese"
+    },
+    {
+        "en": "Romanian"
+    },
+    {
+        "en": "Russian"
+    },
+    {
+        "en": "Rwandan"
+    },
+    {
+        "en": "Sahrawi"
+    },
+    {
+        "en": "Saint Helenian"
+    },
+    {
+        "en": "Saint Maartener"
+    },
+    {
+        "en": "Saint Vincentian"
+    },
+    {
+        "en": "Saint-Martinois"
+    },
+    {
+        "en": "Saint-Pierrais"
+    },
+    {
+        "en": "Salvadoran"
+    },
+    {
+        "en": "Sammarinese"
+    },
+    {
+        "en": "Samoan"
+    },
+    {
+        "en": "São Toméan"
+    },
+    {
+        "en": "Saudi Arabian"
+    },
+    {
+        "en": "Scottish"
+    },
+    {
+        "en": "Senegalese"
+    },
+    {
+        "en": "Serbian"
+    },
+    {
+        "en": "Seychellois"
+    },
+    {
+        "en": "Sierra Leonean"
+    },
+    {
+        "en": "Singaporean"
+    },
+    {
+        "en": "Slovakian"
+    },
+    {
+        "en": "Slovenian"
+    },
+    {
+        "en": "Solomon Islander"
+    },
+    {
+        "en": "Somali"
+    },
+    {
+        "en": "South African"
+    },
+    {
+        "en": "South Georgian"
+    },
+    {
+        "en": "South Korean"
+    },
+    {
+        "en": "South Sandwich Islander"
+    },
+    {
+        "en": "South Sudanese"
+    },
+    {
+        "en": "Spanish"
+    },
+    {
+        "en": "Sri Lankan"
+    },
+    {
+        "en": "St Helenian"
+    },
+    {
+        "en": "Saint Lucian"
+    },
+    {
+        "en": "St Lucian"
+    },
+    {
+        "en": "St Maartener"
+    },
+    {
+        "en": "St Vincentian"
+    },
+    {
+        "en": "Sudanese"
+    },
+    {
+        "en": "Surinamese"
+    },
+    {
+        "en": "Svalbard and Jan Mayen Islander"
+    },
+    {
+        "en": "Swazi"
+    },
+    {
+        "en": "Swedish"
+    },
+    {
+        "en": "Swiss"
+    },
+    {
+        "en": "Syrian"
+    },
+    {
+        "en": "Taiwanese"
+    },
+    {
+        "en": "Tajik"
+    },
+    {
+        "en": "Tanzanian"
+    },
+    {
+        "en": "Thai"
+    },
+    {
+        "en": "Togolese"
+    },
+    {
+        "en": "Tokelauan"
+    },
+    {
+        "en": "Tongan"
+    },
+    {
+        "en": "Trinidadian and Tobagonian"
+    },
+    {
+        "en": "Tunisian"
+    },
+    {
+        "en": "Turkish"
+    },
+    {
+        "en": "Turkish Cypriot"
+    },
+    {
+        "en": "Turkmenistani"
+    },
+    {
+        "en": "Turks and Caicos Islander"
+    },
+    {
+        "en": "Tuvaluan"
+    },
+    {
+        "en": "Ugandan"
+    },
+    {
+        "en": "Ukrainian"
+    },
+    {
+        "en": "Uruguayan"
+    },
+    {
+        "en": "Uzbek"
+    },
+    {
+        "en": "Venezuelan"
+    },
+    {
+        "en": "Vietnamese"
+    },
+    {
+        "en": "Vincentian"
+    },
+    {
+        "en": "Virgin Islander"
+    },
+    {
+        "en": "Wallisian"
+    },
+    {
+        "en": "Welsh"
+    },
+    {
+        "en": "Yemeni"
+    },
+    {
+        "en": "Zambian"
+    },
+    {
+        "en": "Zimbabwean"
+    }
 ]

--- a/data/gb/en/passport-countries.json
+++ b/data/gb/en/passport-countries.json
@@ -1,202 +1,602 @@
 [
-    "United Kingdom",
-    "Ireland",
-    "Afghanistan",
-    "Albania",
-    "Algeria",
-    "Andorra",
-    "Angola",
-    "Antigua and Barbuda",
-    "Argentina",
-    "Armenia",
-    "Australia",
-    "Austria",
-    "Azerbaijan",
-    "Bahrain",
-    "Bangladesh",
-    "Barbados",
-    "Belarus",
-    "Belgium",
-    "Belize",
-    "Benin",
-    "Bhutan",
-    "Bolivia",
-    "Bosnia and Herzegovina",
-    "Botswana",
-    "Brazil",
-    "Brunei",
-    "Bulgaria",
-    "Burkina Faso",
-    "Burundi",
-    "Cambodia",
-    "Cameroon",
-    "Canada",
-    "Cape Verde",
-    "Central African Republic",
-    "Chad",
-    "Chile",
-    "China",
-    "Colombia",
-    "Comoros",
-    "Congo",
-    "Congo (Democratic Republic)",
-    "Costa Rica",
-    "Croatia",
-    "Cuba",
-    "Cyprus",
-    "Czech Republic or Czechia",
-    "Denmark",
-    "Djibouti",
-    "Dominica",
-    "Dominican Republic",
-    "East Timor",
-    "Ecuador",
-    "Egypt",
-    "El Salvador",
-    "Equatorial Guinea",
-    "Eritrea",
-    "Estonia",
-    "Eswatini",
-    "Ethiopia",
-    "Fiji",
-    "Finland",
-    "France",
-    "Gabon",
-    "Georgia",
-    "Germany",
-    "Ghana",
-    "Greece",
-    "Grenada",
-    "Guatemala",
-    "Guinea",
-    "Guinea-Bissau",
-    "Guyana",
-    "Haiti",
-    "Honduras",
-    "Hong Kong",
-    "Hungary",
-    "Iceland",
-    "India",
-    "Indonesia",
-    "Iran",
-    "Iraq",
-    "Israel",
-    "Italy",
-    "Ivory Coast",
-    "Jamaica",
-    "Japan",
-    "Jordan",
-    "Kazakhstan",
-    "Kenya",
-    "Kiribati",
-    "Kosovo",
-    "Kuwait",
-    "Kyrgyzstan",
-    "Laos",
-    "Latvia",
-    "Lebanon",
-    "Lesotho",
-    "Liberia",
-    "Libya",
-    "Liechtenstein",
-    "Lithuania",
-    "Luxembourg",
-    "Macao",
-    "Madagascar",
-    "Malawi",
-    "Malaysia",
-    "Maldives",
-    "Mali",
-    "Malta",
-    "Marshall Islands",
-    "Mauritania",
-    "Mauritius",
-    "Mexico",
-    "Micronesia",
-    "Moldova",
-    "Monaco",
-    "Mongolia",
-    "Montenegro",
-    "Morocco",
-    "Mozambique",
-    "Myanmar (Burma)",
-    "Namibia",
-    "Nauru",
-    "Nepal",
-    "The Netherlands",
-    "New Zealand",
-    "Nicaragua",
-    "Niger",
-    "Nigeria",
-    "North Cyprus",
-    "North Korea",
-    "North Macedonia",
-    "Norway",
-    "Occupied Palestinian Territories",
-    "Oman",
-    "Pakistan",
-    "Palau",
-    "Panama",
-    "Papua New Guinea",
-    "Paraguay",
-    "Peru",
-    "Philippines",
-    "Poland",
-    "Portugal",
-    "Qatar",
-    "Romania",
-    "Russia",
-    "Rwanda",
-    "Samoa",
-    "San Marino",
-    "São Tomé and Príncipe",
-    "Saudi Arabia",
-    "Senegal",
-    "Serbia",
-    "Seychelles",
-    "Sierra Leone",
-    "Singapore",
-    "Slovakia",
-    "Slovenia",
-    "Solomon Islands",
-    "Somalia",
-    "South Africa",
-    "South Korea",
-    "South Sudan",
-    "Spain",
-    "Sri Lanka",
-    "St Kitts and Nevis",
-    "St Lucia",
-    "St Vincent and the Grenadines",
-    "Sudan",
-    "Suriname",
-    "Sweden",
-    "Switzerland",
-    "Syria",
-    "Taiwan",
-    "Tajikistan",
-    "Tanzania",
-    "Thailand",
-    "The Bahamas",
-    "The Gambia",
-    "Togo",
-    "Tonga",
-    "Trinidad and Tobago",
-    "Tunisia",
-    "Turkey",
-    "Turkmenistan",
-    "Tuvalu",
-    "Uganda",
-    "Ukraine",
-    "United Arab Emirates",
-    "United States of America",
-    "Uruguay",
-    "Uzbekistan",
-    "Vanuatu",
-    "Vatican City",
-    "Venezuela",
-    "Vietnam",
-    "Yemen",
-    "Zambia",
-    "Zimbabwe"
+    {
+        "en": "United Kingdom"
+    },
+    {
+        "en": "Ireland"
+    },
+    {
+        "en": "Afghanistan"
+    },
+    {
+        "en": "Albania"
+    },
+    {
+        "en": "Algeria"
+    },
+    {
+        "en": "Andorra"
+    },
+    {
+        "en": "Angola"
+    },
+    {
+        "en": "Antigua and Barbuda"
+    },
+    {
+        "en": "Argentina"
+    },
+    {
+        "en": "Armenia"
+    },
+    {
+        "en": "Australia"
+    },
+    {
+        "en": "Austria"
+    },
+    {
+        "en": "Azerbaijan"
+    },
+    {
+        "en": "Bahrain"
+    },
+    {
+        "en": "Bangladesh"
+    },
+    {
+        "en": "Barbados"
+    },
+    {
+        "en": "Belarus"
+    },
+    {
+        "en": "Belgium"
+    },
+    {
+        "en": "Belize"
+    },
+    {
+        "en": "Benin"
+    },
+    {
+        "en": "Bhutan"
+    },
+    {
+        "en": "Bolivia"
+    },
+    {
+        "en": "Bosnia and Herzegovina"
+    },
+    {
+        "en": "Botswana"
+    },
+    {
+        "en": "Brazil"
+    },
+    {
+        "en": "Brunei"
+    },
+    {
+        "en": "Bulgaria"
+    },
+    {
+        "en": "Burkina Faso"
+    },
+    {
+        "en": "Burundi"
+    },
+    {
+        "en": "Cambodia"
+    },
+    {
+        "en": "Cameroon"
+    },
+    {
+        "en": "Canada"
+    },
+    {
+        "en": "Cape Verde"
+    },
+    {
+        "en": "Central African Republic"
+    },
+    {
+        "en": "Chad"
+    },
+    {
+        "en": "Chile"
+    },
+    {
+        "en": "China"
+    },
+    {
+        "en": "Colombia"
+    },
+    {
+        "en": "Comoros"
+    },
+    {
+        "en": "Congo"
+    },
+    {
+        "en": "Congo (Democratic Republic)"
+    },
+    {
+        "en": "Costa Rica"
+    },
+    {
+        "en": "Croatia"
+    },
+    {
+        "en": "Cuba"
+    },
+    {
+        "en": "Cyprus"
+    },
+    {
+        "en": "Czech Republic or Czechia"
+    },
+    {
+        "en": "Denmark"
+    },
+    {
+        "en": "Djibouti"
+    },
+    {
+        "en": "Dominica"
+    },
+    {
+        "en": "Dominican Republic"
+    },
+    {
+        "en": "East Timor"
+    },
+    {
+        "en": "Ecuador"
+    },
+    {
+        "en": "Egypt"
+    },
+    {
+        "en": "El Salvador"
+    },
+    {
+        "en": "Equatorial Guinea"
+    },
+    {
+        "en": "Eritrea"
+    },
+    {
+        "en": "Estonia"
+    },
+    {
+        "en": "Eswatini"
+    },
+    {
+        "en": "Ethiopia"
+    },
+    {
+        "en": "Fiji"
+    },
+    {
+        "en": "Finland"
+    },
+    {
+        "en": "France"
+    },
+    {
+        "en": "Gabon"
+    },
+    {
+        "en": "Georgia"
+    },
+    {
+        "en": "Germany"
+    },
+    {
+        "en": "Ghana"
+    },
+    {
+        "en": "Greece"
+    },
+    {
+        "en": "Grenada"
+    },
+    {
+        "en": "Guatemala"
+    },
+    {
+        "en": "Guinea"
+    },
+    {
+        "en": "Guinea-Bissau"
+    },
+    {
+        "en": "Guyana"
+    },
+    {
+        "en": "Haiti"
+    },
+    {
+        "en": "Honduras"
+    },
+    {
+        "en": "Hong Kong"
+    },
+    {
+        "en": "Hungary"
+    },
+    {
+        "en": "Iceland"
+    },
+    {
+        "en": "India"
+    },
+    {
+        "en": "Indonesia"
+    },
+    {
+        "en": "Iran"
+    },
+    {
+        "en": "Iraq"
+    },
+    {
+        "en": "Israel"
+    },
+    {
+        "en": "Italy"
+    },
+    {
+        "en": "Ivory Coast"
+    },
+    {
+        "en": "Jamaica"
+    },
+    {
+        "en": "Japan"
+    },
+    {
+        "en": "Jordan"
+    },
+    {
+        "en": "Kazakhstan"
+    },
+    {
+        "en": "Kenya"
+    },
+    {
+        "en": "Kiribati"
+    },
+    {
+        "en": "Kosovo"
+    },
+    {
+        "en": "Kuwait"
+    },
+    {
+        "en": "Kyrgyzstan"
+    },
+    {
+        "en": "Laos"
+    },
+    {
+        "en": "Latvia"
+    },
+    {
+        "en": "Lebanon"
+    },
+    {
+        "en": "Lesotho"
+    },
+    {
+        "en": "Liberia"
+    },
+    {
+        "en": "Libya"
+    },
+    {
+        "en": "Liechtenstein"
+    },
+    {
+        "en": "Lithuania"
+    },
+    {
+        "en": "Luxembourg"
+    },
+    {
+        "en": "Macao"
+    },
+    {
+        "en": "Madagascar"
+    },
+    {
+        "en": "Malawi"
+    },
+    {
+        "en": "Malaysia"
+    },
+    {
+        "en": "Maldives"
+    },
+    {
+        "en": "Mali"
+    },
+    {
+        "en": "Malta"
+    },
+    {
+        "en": "Marshall Islands"
+    },
+    {
+        "en": "Mauritania"
+    },
+    {
+        "en": "Mauritius"
+    },
+    {
+        "en": "Mexico"
+    },
+    {
+        "en": "Micronesia"
+    },
+    {
+        "en": "Moldova"
+    },
+    {
+        "en": "Monaco"
+    },
+    {
+        "en": "Mongolia"
+    },
+    {
+        "en": "Montenegro"
+    },
+    {
+        "en": "Morocco"
+    },
+    {
+        "en": "Mozambique"
+    },
+    {
+        "en": "Myanmar (Burma)"
+    },
+    {
+        "en": "Namibia"
+    },
+    {
+        "en": "Nauru"
+    },
+    {
+        "en": "Nepal"
+    },
+    {
+        "en": "The Netherlands"
+    },
+    {
+        "en": "New Zealand"
+    },
+    {
+        "en": "Nicaragua"
+    },
+    {
+        "en": "Niger"
+    },
+    {
+        "en": "Nigeria"
+    },
+    {
+        "en": "North Cyprus"
+    },
+    {
+        "en": "North Korea"
+    },
+    {
+        "en": "North Macedonia"
+    },
+    {
+        "en": "Norway"
+    },
+    {
+        "en": "Occupied Palestinian Territories"
+    },
+    {
+        "en": "Oman"
+    },
+    {
+        "en": "Pakistan"
+    },
+    {
+        "en": "Palau"
+    },
+    {
+        "en": "Panama"
+    },
+    {
+        "en": "Papua New Guinea"
+    },
+    {
+        "en": "Paraguay"
+    },
+    {
+        "en": "Peru"
+    },
+    {
+        "en": "Philippines"
+    },
+    {
+        "en": "Poland"
+    },
+    {
+        "en": "Portugal"
+    },
+    {
+        "en": "Qatar"
+    },
+    {
+        "en": "Romania"
+    },
+    {
+        "en": "Russia"
+    },
+    {
+        "en": "Rwanda"
+    },
+    {
+        "en": "Samoa"
+    },
+    {
+        "en": "San Marino"
+    },
+    {
+        "en": "São Tomé and Príncipe"
+    },
+    {
+        "en": "Saudi Arabia"
+    },
+    {
+        "en": "Senegal"
+    },
+    {
+        "en": "Serbia"
+    },
+    {
+        "en": "Seychelles"
+    },
+    {
+        "en": "Sierra Leone"
+    },
+    {
+        "en": "Singapore"
+    },
+    {
+        "en": "Slovakia"
+    },
+    {
+        "en": "Slovenia"
+    },
+    {
+        "en": "Solomon Islands"
+    },
+    {
+        "en": "Somalia"
+    },
+    {
+        "en": "South Africa"
+    },
+    {
+        "en": "South Korea"
+    },
+    {
+        "en": "South Sudan"
+    },
+    {
+        "en": "Spain"
+    },
+    {
+        "en": "Sri Lanka"
+    },
+    {
+        "en": "St Kitts and Nevis"
+    },
+    {
+        "en": "St Lucia"
+    },
+    {
+        "en": "St Vincent and the Grenadines"
+    },
+    {
+        "en": "Sudan"
+    },
+    {
+        "en": "Suriname"
+    },
+    {
+        "en": "Sweden"
+    },
+    {
+        "en": "Switzerland"
+    },
+    {
+        "en": "Syria"
+    },
+    {
+        "en": "Taiwan"
+    },
+    {
+        "en": "Tajikistan"
+    },
+    {
+        "en": "Tanzania"
+    },
+    {
+        "en": "Thailand"
+    },
+    {
+        "en": "The Bahamas"
+    },
+    {
+        "en": "The Gambia"
+    },
+    {
+        "en": "Togo"
+    },
+    {
+        "en": "Tonga"
+    },
+    {
+        "en": "Trinidad and Tobago"
+    },
+    {
+        "en": "Tunisia"
+    },
+    {
+        "en": "Turkey"
+    },
+    {
+        "en": "Turkmenistan"
+    },
+    {
+        "en": "Tuvalu"
+    },
+    {
+        "en": "Uganda"
+    },
+    {
+        "en": "Ukraine"
+    },
+    {
+        "en": "United Arab Emirates"
+    },
+    {
+        "en": "United States of America"
+    },
+    {
+        "en": "Uruguay"
+    },
+    {
+        "en": "Uzbekistan"
+    },
+    {
+        "en": "Vanuatu"
+    },
+    {
+        "en": "Vatican City"
+    },
+    {
+        "en": "Venezuela"
+    },
+    {
+        "en": "Vietnam"
+    },
+    {
+        "en": "Yemen"
+    },
+    {
+        "en": "Zambia"
+    },
+    {
+        "en": "Zimbabwe"
+    }
 ]

--- a/data/gb/en/religions.json
+++ b/data/gb/en/religions.json
@@ -1,67 +1,197 @@
 [
-    "Agnostic",
-    "Ahmadi Muslim",
-    "Alevi",
-    "Anglican",
-    "Atheist",
-    "Bahai",
-    "Baptist",
-    "Born Again Christian",
-    "Buddhist",
-    "Catholic",
-    "Chapel",
-    "Christadelphian",
-    "Christian",
-    "Christian Orthodox",
-    "Church in Wales",
-    "Church of Christ",
-    "Church of England",
-    "Church of God",
-    "Church of Scotland",
-    "Coptic Orthodox",
-    "Deist",
-    "Druid",
-    "Evangelical",
-    "Gnostic",
-    "Greek Orthodox",
-    "Hare Krishna",
-    "Hindu",
-    "Holistic",
-    "Independent",
-    "Jain",
-    "Jehovah's Witness",
-    "Jewish",
-    "Kirat",
-    "Latter Day Saint",
-    "Lutheran",
-    "Methodist",
-    "Mormon",
-    "Muslim",
-    "No Religion",
-    "Pagan",
-    "Pantheist",
-    "Pentecostal",
-    "Presbyterian",
-    "Protestant",
-    "Quaker",
-    "Rastafarian",
-    "Ravidassia",
-    "Roman Catholic",
-    "Russian Orthodox",
-    "Salvation Army",
-    "Satanist",
-    "Scientology",
-    "Serbian Orthodox",
-    "Seventh Day Adventist",
-    "Shinto",
-    "Sikh",
-    "Spiritual",
-    "Spiritualist",
-    "Taoist",
-    "Theist",
-    "Unitarian",
-    "Welsh Baptist",
-    "Wiccan",
-    "Yazidi",
-    "Zoroastrian"
+    {
+        "en": "Agnostic"
+    },
+    {
+        "en": "Ahmadi Muslim"
+    },
+    {
+        "en": "Alevi"
+    },
+    {
+        "en": "Anglican"
+    },
+    {
+        "en": "Atheist"
+    },
+    {
+        "en": "Bahai"
+    },
+    {
+        "en": "Baptist"
+    },
+    {
+        "en": "Born Again Christian"
+    },
+    {
+        "en": "Buddhist"
+    },
+    {
+        "en": "Catholic"
+    },
+    {
+        "en": "Chapel"
+    },
+    {
+        "en": "Christadelphian"
+    },
+    {
+        "en": "Christian"
+    },
+    {
+        "en": "Christian Orthodox"
+    },
+    {
+        "en": "Church in Wales"
+    },
+    {
+        "en": "Church of Christ"
+    },
+    {
+        "en": "Church of England"
+    },
+    {
+        "en": "Church of God"
+    },
+    {
+        "en": "Church of Scotland"
+    },
+    {
+        "en": "Coptic Orthodox"
+    },
+    {
+        "en": "Deist"
+    },
+    {
+        "en": "Druid"
+    },
+    {
+        "en": "Evangelical"
+    },
+    {
+        "en": "Gnostic"
+    },
+    {
+        "en": "Greek Orthodox"
+    },
+    {
+        "en": "Hare Krishna"
+    },
+    {
+        "en": "Hindu"
+    },
+    {
+        "en": "Holistic"
+    },
+    {
+        "en": "Independent"
+    },
+    {
+        "en": "Jain"
+    },
+    {
+        "en": "Jehovah's Witness"
+    },
+    {
+        "en": "Jewish"
+    },
+    {
+        "en": "Kirat"
+    },
+    {
+        "en": "Latter Day Saint"
+    },
+    {
+        "en": "Lutheran"
+    },
+    {
+        "en": "Methodist"
+    },
+    {
+        "en": "Mormon"
+    },
+    {
+        "en": "Muslim"
+    },
+    {
+        "en": "No Religion"
+    },
+    {
+        "en": "Pagan"
+    },
+    {
+        "en": "Pantheist"
+    },
+    {
+        "en": "Pentecostal"
+    },
+    {
+        "en": "Presbyterian"
+    },
+    {
+        "en": "Protestant"
+    },
+    {
+        "en": "Quaker"
+    },
+    {
+        "en": "Rastafarian"
+    },
+    {
+        "en": "Ravidassia"
+    },
+    {
+        "en": "Roman Catholic"
+    },
+    {
+        "en": "Russian Orthodox"
+    },
+    {
+        "en": "Salvation Army"
+    },
+    {
+        "en": "Satanist"
+    },
+    {
+        "en": "Scientology"
+    },
+    {
+        "en": "Serbian Orthodox"
+    },
+    {
+        "en": "Seventh Day Adventist"
+    },
+    {
+        "en": "Shinto"
+    },
+    {
+        "en": "Sikh"
+    },
+    {
+        "en": "Spiritual"
+    },
+    {
+        "en": "Spiritualist"
+    },
+    {
+        "en": "Taoist"
+    },
+    {
+        "en": "Theist"
+    },
+    {
+        "en": "Unitarian"
+    },
+    {
+        "en": "Welsh Baptist"
+    },
+    {
+        "en": "Wiccan"
+    },
+    {
+        "en": "Yazidi"
+    },
+    {
+        "en": "Zoroastrian"
+    }
 ]

--- a/data/ni/en/countries-of-birth.json
+++ b/data/ni/en/countries-of-birth.json
@@ -1,253 +1,755 @@
 [
-    "Bonaire, Sint Eustatius and Saba",
-    "Pitcairn, Henderson, Ducie and Oeno Islands",
-    "St Helena, Ascension and Tristan da Cunha",
-    "Afghanistan",
-    "Åland Islands",
-    "Albania",
-    "Algeria",
-    "American Samoa",
-    "Andorra",
-    "Angola",
-    "Anguilla",
-    "Antigua and Barbuda",
-    "Argentina",
-    "Armenia",
-    "Aruba",
-    "Australia",
-    "Austria",
-    "Azerbaijan",
-    "Bahrain",
-    "Bangladesh",
-    "Barbados",
-    "Belarus",
-    "Belgium",
-    "Belize",
-    "Benin",
-    "Bermuda",
-    "Bhutan",
-    "Bolivia",
-    "Bosnia and Herzegovina",
-    "Botswana",
-    "Bouvet Island",
-    "Brazil",
-    "British Indian Ocean Territory",
-    "British Virgin Islands",
-    "Brunei",
-    "Bulgaria",
-    "Burkina Faso",
-    "Burundi",
-    "Cambodia",
-    "Cameroon",
-    "Canada",
-    "Canary Islands",
-    "Cape Verde",
-    "Cayman Islands",
-    "Central African Republic",
-    "Chad",
-    "Channel Islands",
-    "Chile",
-    "China",
-    "Christmas Island",
-    "Cocos (Keeling) Islands",
-    "Colombia",
-    "Comoros",
-    "Congo",
-    "Congo (Democratic Republic)",
-    "Cook Islands",
-    "Costa Rica",
-    "Croatia",
-    "Cuba",
-    "Curaçao",
-    "Cyprus",
-    "Czechia",
-    "Denmark",
-    "Djibouti",
-    "Dominica",
-    "Dominican Republic",
-    "East Timor",
-    "Ecuador",
-    "Egypt",
-    "El Salvador",
-    "England",
-    "Equatorial Guinea",
-    "Eritrea",
-    "Estonia",
-    "Eswatini",
-    "Ethiopia",
-    "Falkland Islands",
-    "Faroe Islands",
-    "Fiji",
-    "Finland",
-    "France",
-    "French Guiana",
-    "French Polynesia",
-    "French Southern Territories",
-    "Gabon",
-    "Georgia",
-    "Germany",
-    "Ghana",
-    "Gibraltar",
-    "Greece",
-    "Greenland",
-    "Grenada",
-    "Guadeloupe",
-    "Guam",
-    "Guatemala",
-    "Guinea",
-    "Guinea-Bissau",
-    "Guyana",
-    "Haiti",
-    "Heard Island and McDonald Islands",
-    "Honduras",
-    "Hong Kong",
-    "Hungary",
-    "Iceland",
-    "India",
-    "Indonesia",
-    "Iran",
-    "Iraq",
-    "Isle of Man",
-    "Israel",
-    "Italy",
-    "Ivory Coast",
-    "Jamaica",
-    "Japan",
-    "Jordan",
-    "Kazakhstan",
-    "Kenya",
-    "Kiribati",
-    "Kosovo",
-    "Kuwait",
-    "Kyrgyzstan",
-    "Laos",
-    "Latvia",
-    "Lebanon",
-    "Lesotho",
-    "Liberia",
-    "Libya",
-    "Liechtenstein",
-    "Lithuania",
-    "Luxembourg",
-    "Macao ",
-    "Madagascar",
-    "Malawi",
-    "Malaysia",
-    "Maldives",
-    "Mali",
-    "Malta",
-    "Marshall Islands",
-    "Martinique",
-    "Mauritania",
-    "Mauritius",
-    "Mayotte",
-    "Mexico",
-    "Micronesia",
-    "Moldova",
-    "Monaco",
-    "Mongolia",
-    "Montenegro",
-    "Montserrat",
-    "Morocco",
-    "Mozambique",
-    "Myanmar (Burma)",
-    "Namibia",
-    "Nauru",
-    "Nepal",
-    "New Caledonia",
-    "New Zealand",
-    "Nicaragua",
-    "Niger",
-    "Nigeria",
-    "Niue",
-    "Norfolk Island",
-    "North Korea",
-    "North Macedonia",
-    "Northern Ireland",
-    "Northern Mariana Islands",
-    "Norway",
-    "Oman",
-    "Pakistan",
-    "Palau",
-    "Panama",
-    "Papua New Guinea",
-    "Paraguay",
-    "Peru",
-    "Philippines",
-    "Poland",
-    "Portugal",
-    "Puerto Rico",
-    "Qatar",
-    "Republic of Ireland",
-    "Réunion",
-    "Romania",
-    "Russia",
-    "Rwanda",
-    "Saint Martin (French part)",
-    "Samoa",
-    "San Marino",
-    "São Tomé and Príncipe",
-    "Saudi Arabia",
-    "Scotland",
-    "Senegal",
-    "Serbia",
-    "Seychelles",
-    "Sierra Leone",
-    "Singapore",
-    "Sint Maarten (Dutch Part)",
-    "Slovakia",
-    "Slovenia",
-    "Solomon Islands",
-    "Somalia",
-    "South Africa",
-    "South Georgia and the South Sandwich Islands",
-    "South Korea",
-    "South Sudan",
-    "Spain (including Balearic Islands) ",
-    "Sri Lanka",
-    "St Barthélemy",
-    "St Kitts and Nevis",
-    "St Lucia",
-    "St Pierre and Miquelon",
-    "St Vincent and the Grenadines",
-    "Sudan",
-    "Suriname",
-    "Svalbard and Jan Mayen",
-    "Sweden",
-    "Switzerland",
-    "Syria",
-    "Taiwan",
-    "Tajikistan",
-    "Tanzania",
-    "Thailand",
-    "The Bahamas",
-    "The Gambia",
-    "The Netherlands",
-    "Togo",
-    "Tokelau",
-    "Tonga",
-    "Trinidad and Tobago",
-    "Tunisia",
-    "Turkey",
-    "Turkmenistan",
-    "Turks and Caicos Islands",
-    "Tuvalu",
-    "Uganda",
-    "Ukraine",
-    "United Arab Emirates",
-    "United States minor outlying islands",
-    "United States of America",
-    "United States Virgin Islands",
-    "Uruguay",
-    "Uzbekistan",
-    "Vanuatu",
-    "Vatican City",
-    "Venezuela",
-    "Vietnam",
-    "Wales",
-    "Wallis and Futuna",
-    "Western Sahara",
-    "Yemen",
-    "Zambia",
-    "Zimbabwe"
+    {
+        "en": "Bonaire, Sint Eustatius and Saba"
+    },
+    {
+        "en": "Pitcairn, Henderson, Ducie and Oeno Islands"
+    },
+    {
+        "en": "St Helena, Ascension and Tristan da Cunha"
+    },
+    {
+        "en": "Afghanistan"
+    },
+    {
+        "en": "Åland Islands"
+    },
+    {
+        "en": "Albania"
+    },
+    {
+        "en": "Algeria"
+    },
+    {
+        "en": "American Samoa"
+    },
+    {
+        "en": "Andorra"
+    },
+    {
+        "en": "Angola"
+    },
+    {
+        "en": "Anguilla"
+    },
+    {
+        "en": "Antigua and Barbuda"
+    },
+    {
+        "en": "Argentina"
+    },
+    {
+        "en": "Armenia"
+    },
+    {
+        "en": "Aruba"
+    },
+    {
+        "en": "Australia"
+    },
+    {
+        "en": "Austria"
+    },
+    {
+        "en": "Azerbaijan"
+    },
+    {
+        "en": "Bahrain"
+    },
+    {
+        "en": "Bangladesh"
+    },
+    {
+        "en": "Barbados"
+    },
+    {
+        "en": "Belarus"
+    },
+    {
+        "en": "Belgium"
+    },
+    {
+        "en": "Belize"
+    },
+    {
+        "en": "Benin"
+    },
+    {
+        "en": "Bermuda"
+    },
+    {
+        "en": "Bhutan"
+    },
+    {
+        "en": "Bolivia"
+    },
+    {
+        "en": "Bosnia and Herzegovina"
+    },
+    {
+        "en": "Botswana"
+    },
+    {
+        "en": "Bouvet Island"
+    },
+    {
+        "en": "Brazil"
+    },
+    {
+        "en": "British Indian Ocean Territory"
+    },
+    {
+        "en": "British Virgin Islands"
+    },
+    {
+        "en": "Brunei"
+    },
+    {
+        "en": "Bulgaria"
+    },
+    {
+        "en": "Burkina Faso"
+    },
+    {
+        "en": "Burundi"
+    },
+    {
+        "en": "Cambodia"
+    },
+    {
+        "en": "Cameroon"
+    },
+    {
+        "en": "Canada"
+    },
+    {
+        "en": "Canary Islands"
+    },
+    {
+        "en": "Cape Verde"
+    },
+    {
+        "en": "Cayman Islands"
+    },
+    {
+        "en": "Central African Republic"
+    },
+    {
+        "en": "Chad"
+    },
+    {
+        "en": "Channel Islands"
+    },
+    {
+        "en": "Chile"
+    },
+    {
+        "en": "China"
+    },
+    {
+        "en": "Christmas Island"
+    },
+    {
+        "en": "Cocos (Keeling) Islands"
+    },
+    {
+        "en": "Colombia"
+    },
+    {
+        "en": "Comoros"
+    },
+    {
+        "en": "Congo"
+    },
+    {
+        "en": "Congo (Democratic Republic)"
+    },
+    {
+        "en": "Cook Islands"
+    },
+    {
+        "en": "Costa Rica"
+    },
+    {
+        "en": "Croatia"
+    },
+    {
+        "en": "Cuba"
+    },
+    {
+        "en": "Curaçao"
+    },
+    {
+        "en": "Cyprus"
+    },
+    {
+        "en": "Czechia"
+    },
+    {
+        "en": "Denmark"
+    },
+    {
+        "en": "Djibouti"
+    },
+    {
+        "en": "Dominica"
+    },
+    {
+        "en": "Dominican Republic"
+    },
+    {
+        "en": "East Timor"
+    },
+    {
+        "en": "Ecuador"
+    },
+    {
+        "en": "Egypt"
+    },
+    {
+        "en": "El Salvador"
+    },
+    {
+        "en": "England"
+    },
+    {
+        "en": "Equatorial Guinea"
+    },
+    {
+        "en": "Eritrea"
+    },
+    {
+        "en": "Estonia"
+    },
+    {
+        "en": "Eswatini"
+    },
+    {
+        "en": "Ethiopia"
+    },
+    {
+        "en": "Falkland Islands"
+    },
+    {
+        "en": "Faroe Islands"
+    },
+    {
+        "en": "Fiji"
+    },
+    {
+        "en": "Finland"
+    },
+    {
+        "en": "France"
+    },
+    {
+        "en": "French Guiana"
+    },
+    {
+        "en": "French Polynesia"
+    },
+    {
+        "en": "French Southern Territories"
+    },
+    {
+        "en": "Gabon"
+    },
+    {
+        "en": "Georgia"
+    },
+    {
+        "en": "Germany"
+    },
+    {
+        "en": "Ghana"
+    },
+    {
+        "en": "Gibraltar"
+    },
+    {
+        "en": "Greece"
+    },
+    {
+        "en": "Greenland"
+    },
+    {
+        "en": "Grenada"
+    },
+    {
+        "en": "Guadeloupe"
+    },
+    {
+        "en": "Guam"
+    },
+    {
+        "en": "Guatemala"
+    },
+    {
+        "en": "Guinea"
+    },
+    {
+        "en": "Guinea-Bissau"
+    },
+    {
+        "en": "Guyana"
+    },
+    {
+        "en": "Haiti"
+    },
+    {
+        "en": "Heard Island and McDonald Islands"
+    },
+    {
+        "en": "Honduras"
+    },
+    {
+        "en": "Hong Kong"
+    },
+    {
+        "en": "Hungary"
+    },
+    {
+        "en": "Iceland"
+    },
+    {
+        "en": "India"
+    },
+    {
+        "en": "Indonesia"
+    },
+    {
+        "en": "Iran"
+    },
+    {
+        "en": "Iraq"
+    },
+    {
+        "en": "Isle of Man"
+    },
+    {
+        "en": "Israel"
+    },
+    {
+        "en": "Italy"
+    },
+    {
+        "en": "Ivory Coast"
+    },
+    {
+        "en": "Jamaica"
+    },
+    {
+        "en": "Japan"
+    },
+    {
+        "en": "Jordan"
+    },
+    {
+        "en": "Kazakhstan"
+    },
+    {
+        "en": "Kenya"
+    },
+    {
+        "en": "Kiribati"
+    },
+    {
+        "en": "Kosovo"
+    },
+    {
+        "en": "Kuwait"
+    },
+    {
+        "en": "Kyrgyzstan"
+    },
+    {
+        "en": "Laos"
+    },
+    {
+        "en": "Latvia"
+    },
+    {
+        "en": "Lebanon"
+    },
+    {
+        "en": "Lesotho"
+    },
+    {
+        "en": "Liberia"
+    },
+    {
+        "en": "Libya"
+    },
+    {
+        "en": "Liechtenstein"
+    },
+    {
+        "en": "Lithuania"
+    },
+    {
+        "en": "Luxembourg"
+    },
+    {
+        "en": "Macao "
+    },
+    {
+        "en": "Madagascar"
+    },
+    {
+        "en": "Malawi"
+    },
+    {
+        "en": "Malaysia"
+    },
+    {
+        "en": "Maldives"
+    },
+    {
+        "en": "Mali"
+    },
+    {
+        "en": "Malta"
+    },
+    {
+        "en": "Marshall Islands"
+    },
+    {
+        "en": "Martinique"
+    },
+    {
+        "en": "Mauritania"
+    },
+    {
+        "en": "Mauritius"
+    },
+    {
+        "en": "Mayotte"
+    },
+    {
+        "en": "Mexico"
+    },
+    {
+        "en": "Micronesia"
+    },
+    {
+        "en": "Moldova"
+    },
+    {
+        "en": "Monaco"
+    },
+    {
+        "en": "Mongolia"
+    },
+    {
+        "en": "Montenegro"
+    },
+    {
+        "en": "Montserrat"
+    },
+    {
+        "en": "Morocco"
+    },
+    {
+        "en": "Mozambique"
+    },
+    {
+        "en": "Myanmar (Burma)"
+    },
+    {
+        "en": "Namibia"
+    },
+    {
+        "en": "Nauru"
+    },
+    {
+        "en": "Nepal"
+    },
+    {
+        "en": "New Caledonia"
+    },
+    {
+        "en": "New Zealand"
+    },
+    {
+        "en": "Nicaragua"
+    },
+    {
+        "en": "Niger"
+    },
+    {
+        "en": "Nigeria"
+    },
+    {
+        "en": "Niue"
+    },
+    {
+        "en": "Norfolk Island"
+    },
+    {
+        "en": "North Korea"
+    },
+    {
+        "en": "North Macedonia"
+    },
+    {
+        "en": "Northern Ireland"
+    },
+    {
+        "en": "Northern Mariana Islands"
+    },
+    {
+        "en": "Norway"
+    },
+    {
+        "en": "Oman"
+    },
+    {
+        "en": "Pakistan"
+    },
+    {
+        "en": "Palau"
+    },
+    {
+        "en": "Panama"
+    },
+    {
+        "en": "Papua New Guinea"
+    },
+    {
+        "en": "Paraguay"
+    },
+    {
+        "en": "Peru"
+    },
+    {
+        "en": "Philippines"
+    },
+    {
+        "en": "Poland"
+    },
+    {
+        "en": "Portugal"
+    },
+    {
+        "en": "Puerto Rico"
+    },
+    {
+        "en": "Qatar"
+    },
+    {
+        "en": "Republic of Ireland"
+    },
+    {
+        "en": "Réunion"
+    },
+    {
+        "en": "Romania"
+    },
+    {
+        "en": "Russia"
+    },
+    {
+        "en": "Rwanda"
+    },
+    {
+        "en": "Saint Martin (French part)"
+    },
+    {
+        "en": "Samoa"
+    },
+    {
+        "en": "San Marino"
+    },
+    {
+        "en": "São Tomé and Príncipe"
+    },
+    {
+        "en": "Saudi Arabia"
+    },
+    {
+        "en": "Scotland"
+    },
+    {
+        "en": "Senegal"
+    },
+    {
+        "en": "Serbia"
+    },
+    {
+        "en": "Seychelles"
+    },
+    {
+        "en": "Sierra Leone"
+    },
+    {
+        "en": "Singapore"
+    },
+    {
+        "en": "Sint Maarten (Dutch Part)"
+    },
+    {
+        "en": "Slovakia"
+    },
+    {
+        "en": "Slovenia"
+    },
+    {
+        "en": "Solomon Islands"
+    },
+    {
+        "en": "Somalia"
+    },
+    {
+        "en": "South Africa"
+    },
+    {
+        "en": "South Georgia and the South Sandwich Islands"
+    },
+    {
+        "en": "South Korea"
+    },
+    {
+        "en": "South Sudan"
+    },
+    {
+        "en": "Spain (including Balearic Islands) "
+    },
+    {
+        "en": "Sri Lanka"
+    },
+    {
+        "en": "St Barthélemy"
+    },
+    {
+        "en": "St Kitts and Nevis"
+    },
+    {
+        "en": "St Lucia"
+    },
+    {
+        "en": "St Pierre and Miquelon"
+    },
+    {
+        "en": "St Vincent and the Grenadines"
+    },
+    {
+        "en": "Sudan"
+    },
+    {
+        "en": "Suriname"
+    },
+    {
+        "en": "Svalbard and Jan Mayen"
+    },
+    {
+        "en": "Sweden"
+    },
+    {
+        "en": "Switzerland"
+    },
+    {
+        "en": "Syria"
+    },
+    {
+        "en": "Taiwan"
+    },
+    {
+        "en": "Tajikistan"
+    },
+    {
+        "en": "Tanzania"
+    },
+    {
+        "en": "Thailand"
+    },
+    {
+        "en": "The Bahamas"
+    },
+    {
+        "en": "The Gambia"
+    },
+    {
+        "en": "The Netherlands"
+    },
+    {
+        "en": "Togo"
+    },
+    {
+        "en": "Tokelau"
+    },
+    {
+        "en": "Tonga"
+    },
+    {
+        "en": "Trinidad and Tobago"
+    },
+    {
+        "en": "Tunisia"
+    },
+    {
+        "en": "Turkey"
+    },
+    {
+        "en": "Turkmenistan"
+    },
+    {
+        "en": "Turks and Caicos Islands"
+    },
+    {
+        "en": "Tuvalu"
+    },
+    {
+        "en": "Uganda"
+    },
+    {
+        "en": "Ukraine"
+    },
+    {
+        "en": "United Arab Emirates"
+    },
+    {
+        "en": "United States minor outlying islands"
+    },
+    {
+        "en": "United States of America"
+    },
+    {
+        "en": "United States Virgin Islands"
+    },
+    {
+        "en": "Uruguay"
+    },
+    {
+        "en": "Uzbekistan"
+    },
+    {
+        "en": "Vanuatu"
+    },
+    {
+        "en": "Vatican City"
+    },
+    {
+        "en": "Venezuela"
+    },
+    {
+        "en": "Vietnam"
+    },
+    {
+        "en": "Wales"
+    },
+    {
+        "en": "Wallis and Futuna"
+    },
+    {
+        "en": "Western Sahara"
+    },
+    {
+        "en": "Yemen"
+    },
+    {
+        "en": "Zambia"
+    },
+    {
+        "en": "Zimbabwe"
+    }
 ]

--- a/data/ni/en/ethnic-groups.json
+++ b/data/ni/en/ethnic-groups.json
@@ -1,44 +1,128 @@
 [
-    "African",
-    "Arab",
-    "Baltic States",
-    "Bangladeshi",
-    "Black African",
-    "Black Caribbean ",
-    "Black Other",
-    "Brazilian",
-    "British",
-    "Caribbean",
-    "Chinese",
-    "English",
-    "Filipino ",
-    "Indian",
-    "Indonesian",
-    "Iranian",
-    "Irish",
-    "Irish Traveller ",
-    "Japanese",
-    "Jewish",
-    "Korean",
-    "Kurdish",
-    "Latin/South American",
-    "Malaysian",
-    "Melanesia",
-    "Micronesia",
-    "Muslim",
-    "Nepalese",
-    "North African",
-    "Northern Irish",
-    "Pakistani",
-    "Polish",
-    "Polynesia",
-    "Roma",
-    "Scottish",
-    "Sri Lankan",
-    "Thai",
-    "Turkish",
-    "Ulster-Scot",
-    "Vietnamese",
-    "Welsh",
-    "White"
+    {
+        "en": "African"
+    },
+    {
+        "en": "Arab"
+    },
+    {
+        "en": "Baltic States"
+    },
+    {
+        "en": "Bangladeshi"
+    },
+    {
+        "en": "Black African"
+    },
+    {
+        "en": "Black Caribbean "
+    },
+    {
+        "en": "Black Other"
+    },
+    {
+        "en": "Brazilian"
+    },
+    {
+        "en": "British"
+    },
+    {
+        "en": "Caribbean"
+    },
+    {
+        "en": "Chinese"
+    },
+    {
+        "en": "English"
+    },
+    {
+        "en": "Filipino "
+    },
+    {
+        "en": "Indian"
+    },
+    {
+        "en": "Indonesian"
+    },
+    {
+        "en": "Iranian"
+    },
+    {
+        "en": "Irish"
+    },
+    {
+        "en": "Irish Traveller "
+    },
+    {
+        "en": "Japanese"
+    },
+    {
+        "en": "Jewish"
+    },
+    {
+        "en": "Korean"
+    },
+    {
+        "en": "Kurdish"
+    },
+    {
+        "en": "Latin/South American"
+    },
+    {
+        "en": "Malaysian"
+    },
+    {
+        "en": "Melanesia"
+    },
+    {
+        "en": "Micronesia"
+    },
+    {
+        "en": "Muslim"
+    },
+    {
+        "en": "Nepalese"
+    },
+    {
+        "en": "North African"
+    },
+    {
+        "en": "Northern Irish"
+    },
+    {
+        "en": "Pakistani"
+    },
+    {
+        "en": "Polish"
+    },
+    {
+        "en": "Polynesia"
+    },
+    {
+        "en": "Roma"
+    },
+    {
+        "en": "Scottish"
+    },
+    {
+        "en": "Sri Lankan"
+    },
+    {
+        "en": "Thai"
+    },
+    {
+        "en": "Turkish"
+    },
+    {
+        "en": "Ulster-Scot"
+    },
+    {
+        "en": "Vietnamese"
+    },
+    {
+        "en": "Welsh"
+    },
+    {
+        "en": "White"
+    }
 ]

--- a/data/ni/en/languages.json
+++ b/data/ni/en/languages.json
@@ -1,179 +1,533 @@
 [
-    "Abkhazian",
-    "Afar",
-    "Afrikaans",
-    "Albanian",
-    "Amharic",
-    "Arabic",
-    "Aragonese",
-    "Armenian",
-    "Assamese",
-    "Aymara",
-    "Azerbaijani",
-    "Bambara",
-    "Bashkir",
-    "Basque",
-    "Belarusian",
-    "Bengali or Bangla",
-    "Bihari languages",
-    "Bislama",
-    "Bosnian",
-    "Breton",
-    "British Sign Language",
-    "Bulgarian",
-    "Burmese",
-    "Cantonese",
-    "Castilian",
-    "Catalan",
-    "Chechen",
-    "Chewa",
-    "Chichewa",
-    "Chinese",
-    "Chuvash",
-    "Cornish",
-    "Cree",
-    "Croatian",
-    "Cymraeg",
-    "Czech",
-    "Danish",
-    "Dari",
-    "Dhivehi",
-    "Dutch",
-    "Dzongkha",
-    "English",
-    "Estonian",
-    "Ewe",
-    "Faroese",
-    "Fijian",
-    "Filipino",
-    "Finnish",
-    "Flemish",
-    "French",
-    "Fulah",
-    "Gaelic",
-    "Ganda",
-    "Georgian",
-    "German",
-    "Gikuyu",
-    "Greek",
-    "Greenlandic",
-    "Guarani",
-    "Gujarati",
-    "Haitian",
-    "Haitian Creole",
-    "Hausa",
-    "Hebrew",
-    "Herero",
-    "Hindi",
-    "Hungarian",
-    "Icelandic",
-    "Igbo",
-    "Indonesian",
-    "Irish",
-    "Irish sign language",
-    "Italian",
-    "Japanese",
-    "Javanese",
-    "Kannada",
-    "Kanuri",
-    "Kashmiri",
-    "Kazakh",
-    "Kikuyu",
-    "Kinyarwanda",
-    "Komi",
-    "Korean",
-    "Kurdish",
-    "Kwanyama",
-    "Kyrgyz",
-    "Lao",
-    "Latvian",
-    "Letzeburgesch",
-    "Lingala",
-    "Lithuanian",
-    "Luxembourgish",
-    "Macedonian",
-    "Malagasy",
-    "Malay",
-    "Malayalam",
-    "Maldivian",
-    "Maltese",
-    "Mandarin",
-    "Manx",
-    "Maori",
-    "Marathi",
-    "Mirpuri",
-    "Moldavian",
-    "Moldovan",
-    "Mongolian",
-    "Navajo",
-    "Nepali",
-    "North Ndebele",
-    "Norwegian",
-    "Norwegian Bokmål",
-    "Norwegian Nynorsk",
-    "Nyanja",
-    "Oriya",
-    "Oromo",
-    "Panjabi",
-    "Pashto",
-    "Persian or Farsi",
-    "Polish",
-    "Portuguese",
-    "Punjabi",
-    "Pushto",
-    "Quechua",
-    "Romanian",
-    "Romansh",
-    "Rundi",
-    "Russian",
-    "Samoan",
-    "Sango",
-    "Scottish Gaelic",
-    "Serbian",
-    "Shona",
-    "Sindhi",
-    "Sinhala",
-    "Sinhalese",
-    "Slovak",
-    "Slovenian",
-    "Somali",
-    "South Ndebele",
-    "Southern Sotho",
-    "Spanish",
-    "Sundanese",
-    "Swahili",
-    "Swati",
-    "Swedish",
-    "Sylheti",
-    "Tagalog",
-    "Tahitian",
-    "Tajik",
-    "Tamil",
-    "Tatar",
-    "Telugu",
-    "Thai",
-    "Tibetan",
-    "Tigrinya",
-    "Tonga (Tonga Islands)",
-    "Tsonga",
-    "Tswana",
-    "Turkish",
-    "Turkmen",
-    "Twi",
-    "Uighur",
-    "Ukrainian",
-    "Ulster-Scots",
-    "Urdu",
-    "Uyghur",
-    "Uzbek",
-    "Venda",
-    "Vietnamese",
-    "Walloon",
-    "Welsh",
-    "Wolof",
-    "Xhosa",
-    "Yiddish",
-    "Yoruba",
-    "Zhuang",
-    "Zulu"
+    {
+        "en": "Abkhazian"
+    },
+    {
+        "en": "Afar"
+    },
+    {
+        "en": "Afrikaans"
+    },
+    {
+        "en": "Albanian"
+    },
+    {
+        "en": "Amharic"
+    },
+    {
+        "en": "Arabic"
+    },
+    {
+        "en": "Aragonese"
+    },
+    {
+        "en": "Armenian"
+    },
+    {
+        "en": "Assamese"
+    },
+    {
+        "en": "Aymara"
+    },
+    {
+        "en": "Azerbaijani"
+    },
+    {
+        "en": "Bambara"
+    },
+    {
+        "en": "Bashkir"
+    },
+    {
+        "en": "Basque"
+    },
+    {
+        "en": "Belarusian"
+    },
+    {
+        "en": "Bengali or Bangla"
+    },
+    {
+        "en": "Bihari languages"
+    },
+    {
+        "en": "Bislama"
+    },
+    {
+        "en": "Bosnian"
+    },
+    {
+        "en": "Breton"
+    },
+    {
+        "en": "British Sign Language"
+    },
+    {
+        "en": "Bulgarian"
+    },
+    {
+        "en": "Burmese"
+    },
+    {
+        "en": "Cantonese"
+    },
+    {
+        "en": "Castilian"
+    },
+    {
+        "en": "Catalan"
+    },
+    {
+        "en": "Chechen"
+    },
+    {
+        "en": "Chewa"
+    },
+    {
+        "en": "Chichewa"
+    },
+    {
+        "en": "Chinese"
+    },
+    {
+        "en": "Chuvash"
+    },
+    {
+        "en": "Cornish"
+    },
+    {
+        "en": "Cree"
+    },
+    {
+        "en": "Croatian"
+    },
+    {
+        "en": "Cymraeg"
+    },
+    {
+        "en": "Czech"
+    },
+    {
+        "en": "Danish"
+    },
+    {
+        "en": "Dari"
+    },
+    {
+        "en": "Dhivehi"
+    },
+    {
+        "en": "Dutch"
+    },
+    {
+        "en": "Dzongkha"
+    },
+    {
+        "en": "English"
+    },
+    {
+        "en": "Estonian"
+    },
+    {
+        "en": "Ewe"
+    },
+    {
+        "en": "Faroese"
+    },
+    {
+        "en": "Fijian"
+    },
+    {
+        "en": "Filipino"
+    },
+    {
+        "en": "Finnish"
+    },
+    {
+        "en": "Flemish"
+    },
+    {
+        "en": "French"
+    },
+    {
+        "en": "Fulah"
+    },
+    {
+        "en": "Gaelic"
+    },
+    {
+        "en": "Ganda"
+    },
+    {
+        "en": "Georgian"
+    },
+    {
+        "en": "German"
+    },
+    {
+        "en": "Gikuyu"
+    },
+    {
+        "en": "Greek"
+    },
+    {
+        "en": "Greenlandic"
+    },
+    {
+        "en": "Guarani"
+    },
+    {
+        "en": "Gujarati"
+    },
+    {
+        "en": "Haitian"
+    },
+    {
+        "en": "Haitian Creole"
+    },
+    {
+        "en": "Hausa"
+    },
+    {
+        "en": "Hebrew"
+    },
+    {
+        "en": "Herero"
+    },
+    {
+        "en": "Hindi"
+    },
+    {
+        "en": "Hungarian"
+    },
+    {
+        "en": "Icelandic"
+    },
+    {
+        "en": "Igbo"
+    },
+    {
+        "en": "Indonesian"
+    },
+    {
+        "en": "Irish"
+    },
+    {
+        "en": "Irish sign language"
+    },
+    {
+        "en": "Italian"
+    },
+    {
+        "en": "Japanese"
+    },
+    {
+        "en": "Javanese"
+    },
+    {
+        "en": "Kannada"
+    },
+    {
+        "en": "Kanuri"
+    },
+    {
+        "en": "Kashmiri"
+    },
+    {
+        "en": "Kazakh"
+    },
+    {
+        "en": "Kikuyu"
+    },
+    {
+        "en": "Kinyarwanda"
+    },
+    {
+        "en": "Komi"
+    },
+    {
+        "en": "Korean"
+    },
+    {
+        "en": "Kurdish"
+    },
+    {
+        "en": "Kwanyama"
+    },
+    {
+        "en": "Kyrgyz"
+    },
+    {
+        "en": "Lao"
+    },
+    {
+        "en": "Latvian"
+    },
+    {
+        "en": "Letzeburgesch"
+    },
+    {
+        "en": "Lingala"
+    },
+    {
+        "en": "Lithuanian"
+    },
+    {
+        "en": "Luxembourgish"
+    },
+    {
+        "en": "Macedonian"
+    },
+    {
+        "en": "Malagasy"
+    },
+    {
+        "en": "Malay"
+    },
+    {
+        "en": "Malayalam"
+    },
+    {
+        "en": "Maldivian"
+    },
+    {
+        "en": "Maltese"
+    },
+    {
+        "en": "Mandarin"
+    },
+    {
+        "en": "Manx"
+    },
+    {
+        "en": "Maori"
+    },
+    {
+        "en": "Marathi"
+    },
+    {
+        "en": "Mirpuri"
+    },
+    {
+        "en": "Moldavian"
+    },
+    {
+        "en": "Moldovan"
+    },
+    {
+        "en": "Mongolian"
+    },
+    {
+        "en": "Navajo"
+    },
+    {
+        "en": "Nepali"
+    },
+    {
+        "en": "North Ndebele"
+    },
+    {
+        "en": "Norwegian"
+    },
+    {
+        "en": "Norwegian Bokmål"
+    },
+    {
+        "en": "Norwegian Nynorsk"
+    },
+    {
+        "en": "Nyanja"
+    },
+    {
+        "en": "Oriya"
+    },
+    {
+        "en": "Oromo"
+    },
+    {
+        "en": "Panjabi"
+    },
+    {
+        "en": "Pashto"
+    },
+    {
+        "en": "Persian or Farsi"
+    },
+    {
+        "en": "Polish"
+    },
+    {
+        "en": "Portuguese"
+    },
+    {
+        "en": "Punjabi"
+    },
+    {
+        "en": "Pushto"
+    },
+    {
+        "en": "Quechua"
+    },
+    {
+        "en": "Romanian"
+    },
+    {
+        "en": "Romansh"
+    },
+    {
+        "en": "Rundi"
+    },
+    {
+        "en": "Russian"
+    },
+    {
+        "en": "Samoan"
+    },
+    {
+        "en": "Sango"
+    },
+    {
+        "en": "Scottish Gaelic"
+    },
+    {
+        "en": "Serbian"
+    },
+    {
+        "en": "Shona"
+    },
+    {
+        "en": "Sindhi"
+    },
+    {
+        "en": "Sinhala"
+    },
+    {
+        "en": "Sinhalese"
+    },
+    {
+        "en": "Slovak"
+    },
+    {
+        "en": "Slovenian"
+    },
+    {
+        "en": "Somali"
+    },
+    {
+        "en": "South Ndebele"
+    },
+    {
+        "en": "Southern Sotho"
+    },
+    {
+        "en": "Spanish"
+    },
+    {
+        "en": "Sundanese"
+    },
+    {
+        "en": "Swahili"
+    },
+    {
+        "en": "Swati"
+    },
+    {
+        "en": "Swedish"
+    },
+    {
+        "en": "Sylheti"
+    },
+    {
+        "en": "Tagalog"
+    },
+    {
+        "en": "Tahitian"
+    },
+    {
+        "en": "Tajik"
+    },
+    {
+        "en": "Tamil"
+    },
+    {
+        "en": "Tatar"
+    },
+    {
+        "en": "Telugu"
+    },
+    {
+        "en": "Thai"
+    },
+    {
+        "en": "Tibetan"
+    },
+    {
+        "en": "Tigrinya"
+    },
+    {
+        "en": "Tonga (Tonga Islands)"
+    },
+    {
+        "en": "Tsonga"
+    },
+    {
+        "en": "Tswana"
+    },
+    {
+        "en": "Turkish"
+    },
+    {
+        "en": "Turkmen"
+    },
+    {
+        "en": "Twi"
+    },
+    {
+        "en": "Uighur"
+    },
+    {
+        "en": "Ukrainian"
+    },
+    {
+        "en": "Ulster-Scots"
+    },
+    {
+        "en": "Urdu"
+    },
+    {
+        "en": "Uyghur"
+    },
+    {
+        "en": "Uzbek"
+    },
+    {
+        "en": "Venda"
+    },
+    {
+        "en": "Vietnamese"
+    },
+    {
+        "en": "Walloon"
+    },
+    {
+        "en": "Welsh"
+    },
+    {
+        "en": "Wolof"
+    },
+    {
+        "en": "Xhosa"
+    },
+    {
+        "en": "Yiddish"
+    },
+    {
+        "en": "Yoruba"
+    },
+    {
+        "en": "Zhuang"
+    },
+    {
+        "en": "Zulu"
+    }
 ]

--- a/data/ni/en/national-identities.json
+++ b/data/ni/en/national-identities.json
@@ -1,283 +1,845 @@
 [
-    "Afghan",
-    "African",
-    "Ålandic",
-    "Albanian",
-    "Algerian",
-    "American",
-    "American Islander",
-    "American Samoan",
-    "Andorran",
-    "Angolan",
-    "Anguillian",
-    "Antiguan",
-    "Argentinian",
-    "Armenian",
-    "Aruban",
-    "Asian",
-    "Australian",
-    "Austrian",
-    "Azerbaijani",
-    "Bahamian",
-    "Bahraini",
-    "Bangladeshi",
-    "Barbadian",
-    "Barbudan",
-    "Barthélemois",
-    "Batswana",
-    "Belarusian",
-    "Belgian",
-    "Belizean",
-    "Beninese",
-    "Bermudian",
-    "Bhutanese",
-    "Bissau-Guinean",
-    "Bolivian",
-    "Bonairean",
-    "Bosnian",
-    "Brazilian",
-    "British",
-    "Bruneian",
-    "Bulgarian",
-    "Burkinese",
-    "Burmese",
-    "Burundian",
-    "Cambodian",
-    "Cameroonian",
-    "Canadian",
-    "Canarian",
-    "Cape Verdean",
-    "Caymanian",
-    "Central African",
-    "Chadian",
-    "Chagos Islander",
-    "Channel Islander",
-    "Chilean",
-    "Chinese",
-    "Christmas Islander",
-    "Cocos Islander",
-    "Colombian",
-    "Comorian",
-    "Congolese (Democratic Republic of Congo)",
-    "Congolese (Republic of Congo)",
-    "Cook Islander",
-    "Cornish",
-    "Costa Rican",
-    "Croatian",
-    "Cuban",
-    "Curaçaoan",
-    "Cypriot",
-    "Czech",
-    "Danish",
-    "Djiboutian",
-    "Dominican (Dominica)",
-    "Dominican (Dominican Republic)",
-    "Dutch",
-    "East Timorese",
-    "Ecuadorian",
-    "Egyptian",
-    "Emirati",
-    "English",
-    "Equatoguinean",
-    "Equatorial Guinean",
-    "Eritrean",
-    "Estonian",
-    "Ethiopian",
-    "European",
-    "Falkland Islander",
-    "Faroese",
-    "Fijian",
-    "Filipina",
-    "Filipino",
-    "Finnish",
-    "French",
-    "French Polynesian",
-    "Futunan",
-    "Gabonese",
-    "Gambian",
-    "Georgian",
-    "German",
-    "Ghanaian",
-    "Gibraltarian",
-    "Greek",
-    "Greek Cypriot",
-    "Greenlandic",
-    "Grenadian",
-    "Guadeloupean",
-    "Guamanian",
-    "Guatemalan",
-    "Guianan",
-    "Guinean (Guinea)",
-    "Guinean (Guinea-Bissau)",
-    "Guyanese",
-    "Haitian",
-    "Honduran",
-    "Hong Kong Chinese",
-    "HongKonger",
-    "Hungarian",
-    "Icelandic",
-    "I-Kiribati",
-    "Indian",
-    "Indonesian",
-    "Iranian",
-    "Iraqi",
-    "Irish",
-    "Israeli",
-    "Italian",
-    "Ivorian",
-    "Jamaican",
-    "Japanese",
-    "Jordanian",
-    "Kazakhstani",
-    "Kenyan",
-    "Kernewek",
-    "Kernouak",
-    "Kernowek",
-    "Kernowyon",
-    "Kittitian",
-    "Korean",
-    "Kosovan",
-    "Kurdish",
-    "Kuwaiti",
-    "Kyrgyz",
-    "Lao",
-    "Latvian",
-    "Lebanese",
-    "Lesothan",
-    "Liberian",
-    "Libyan",
-    "Liechtensteiner",
-    "Lithuanian",
-    "Luxembourger",
-    "Macau",
-    "Macedonian",
-    "Madagascan",
-    "Malawian",
-    "Malaysian",
-    "Maldivian",
-    "Malian",
-    "Maltese",
-    "Manx",
-    "Maori",
-    "Marshallese",
-    "Martiniquan",
-    "Mauritanian",
-    "Mauritian",
-    "Mexican",
-    "Micronesian",
-    "Miquelonnais",
-    "Moldovan",
-    "Monacan",
-    "Mongolian",
-    "Montenegrin",
-    "Montserratian",
-    "Moroccan",
-    "Motswana",
-    "Mozambican",
-    "Myanma",
-    "Namibian",
-    "Nauruan",
-    "Nepalese",
-    "Nevisian",
-    "New Caledonian",
-    "New Zealander",
-    "Nicaraguan",
-    "Nigerian (Nigeria)",
-    "Nigerien (Niger)",
-    "Niuean",
-    "Ni-Vanuatu",
-    "Norfolk Islander",
-    "North Korean",
-    "Northern Irish",
-    "Northern Mariana Islander ",
-    "Norwegian",
-    "Omani",
-    "Pakistani",
-    "Palauan",
-    "Palestinian",
-    "Panamanian",
-    "Papua New Guinean",
-    "Paraguayan",
-    "Peruvian",
-    "Pitcairn Islander",
-    "Polish",
-    "Portuguese",
-    "Puerto Rican",
-    "Qatari",
-    "Quisqueyan ",
-    "Réunionese",
-    "Romanian",
-    "Russian",
-    "Rwandan",
-    "Sabian",
-    "Sahrawi",
-    "Saint Helenian",
-    "Saint Lucian",
-    "Saint Maartener",
-    "Saint Vincentian",
-    "Saint-Martinois",
-    "Saint-Pierrais",
-    "Salvadoran",
-    "Sammarinese",
-    "Samoan",
-    "São Toméan",
-    "Saudi Arabian",
-    "Scottish",
-    "Senegalese",
-    "Serbian",
-    "Seychellois",
-    "Sierra Leonean",
-    "Singaporean",
-    "Slovakian",
-    "Slovenian",
-    "Solomon Islander",
-    "Somali",
-    "South African",
-    "South Georgian",
-    "South Korean",
-    "South Sandwich Islander",
-    "South Sudanese",
-    "Spanish",
-    "Sri Lankan",
-    "St Helenian",
-    "St Lucian",
-    "St Maartener",
-    "St Vincentian",
-    "Statian",
-    "Sudanese",
-    "Surinamese",
-    "Svalbard and Jan Mayen Islander",
-    "Swazi",
-    "Swedish",
-    "Swiss",
-    "Syrian",
-    "Taiwanese",
-    "Tajik",
-    "Tanzanian",
-    "Thai",
-    "Togolese",
-    "Tokelauan",
-    "Tongan",
-    "Trinidadian and Tobagonian",
-    "Tunisian",
-    "Turkish",
-    "Turkish Cypriot",
-    "Turkmenistani",
-    "Turks and Caicos Islander",
-    "Tuvaluan",
-    "Ugandan",
-    "Ukrainian",
-    "Ulster-Scots",
-    "Uruguayan",
-    "US citizen ",
-    "Uzbek",
-    "Venezuelan",
-    "Vietnamese",
-    "Vincentian",
-    "Virgin Islander",
-    "Wallisian",
-    "Welsh",
-    "Yemeni",
-    "Zambian",
-    "Zimbabwean"
+    {
+        "en": "Afghan"
+    },
+    {
+        "en": "African"
+    },
+    {
+        "en": "Ålandic"
+    },
+    {
+        "en": "Albanian"
+    },
+    {
+        "en": "Algerian"
+    },
+    {
+        "en": "American"
+    },
+    {
+        "en": "American Islander"
+    },
+    {
+        "en": "American Samoan"
+    },
+    {
+        "en": "Andorran"
+    },
+    {
+        "en": "Angolan"
+    },
+    {
+        "en": "Anguillian"
+    },
+    {
+        "en": "Antiguan"
+    },
+    {
+        "en": "Argentinian"
+    },
+    {
+        "en": "Armenian"
+    },
+    {
+        "en": "Aruban"
+    },
+    {
+        "en": "Asian"
+    },
+    {
+        "en": "Australian"
+    },
+    {
+        "en": "Austrian"
+    },
+    {
+        "en": "Azerbaijani"
+    },
+    {
+        "en": "Bahamian"
+    },
+    {
+        "en": "Bahraini"
+    },
+    {
+        "en": "Bangladeshi"
+    },
+    {
+        "en": "Barbadian"
+    },
+    {
+        "en": "Barbudan"
+    },
+    {
+        "en": "Barthélemois"
+    },
+    {
+        "en": "Batswana"
+    },
+    {
+        "en": "Belarusian"
+    },
+    {
+        "en": "Belgian"
+    },
+    {
+        "en": "Belizean"
+    },
+    {
+        "en": "Beninese"
+    },
+    {
+        "en": "Bermudian"
+    },
+    {
+        "en": "Bhutanese"
+    },
+    {
+        "en": "Bissau-Guinean"
+    },
+    {
+        "en": "Bolivian"
+    },
+    {
+        "en": "Bonairean"
+    },
+    {
+        "en": "Bosnian"
+    },
+    {
+        "en": "Brazilian"
+    },
+    {
+        "en": "British"
+    },
+    {
+        "en": "Bruneian"
+    },
+    {
+        "en": "Bulgarian"
+    },
+    {
+        "en": "Burkinese"
+    },
+    {
+        "en": "Burmese"
+    },
+    {
+        "en": "Burundian"
+    },
+    {
+        "en": "Cambodian"
+    },
+    {
+        "en": "Cameroonian"
+    },
+    {
+        "en": "Canadian"
+    },
+    {
+        "en": "Canarian"
+    },
+    {
+        "en": "Cape Verdean"
+    },
+    {
+        "en": "Caymanian"
+    },
+    {
+        "en": "Central African"
+    },
+    {
+        "en": "Chadian"
+    },
+    {
+        "en": "Chagos Islander"
+    },
+    {
+        "en": "Channel Islander"
+    },
+    {
+        "en": "Chilean"
+    },
+    {
+        "en": "Chinese"
+    },
+    {
+        "en": "Christmas Islander"
+    },
+    {
+        "en": "Cocos Islander"
+    },
+    {
+        "en": "Colombian"
+    },
+    {
+        "en": "Comorian"
+    },
+    {
+        "en": "Congolese (Democratic Republic of Congo)"
+    },
+    {
+        "en": "Congolese (Republic of Congo)"
+    },
+    {
+        "en": "Cook Islander"
+    },
+    {
+        "en": "Cornish"
+    },
+    {
+        "en": "Costa Rican"
+    },
+    {
+        "en": "Croatian"
+    },
+    {
+        "en": "Cuban"
+    },
+    {
+        "en": "Curaçaoan"
+    },
+    {
+        "en": "Cypriot"
+    },
+    {
+        "en": "Czech"
+    },
+    {
+        "en": "Danish"
+    },
+    {
+        "en": "Djiboutian"
+    },
+    {
+        "en": "Dominican (Dominica)"
+    },
+    {
+        "en": "Dominican (Dominican Republic)"
+    },
+    {
+        "en": "Dutch"
+    },
+    {
+        "en": "East Timorese"
+    },
+    {
+        "en": "Ecuadorian"
+    },
+    {
+        "en": "Egyptian"
+    },
+    {
+        "en": "Emirati"
+    },
+    {
+        "en": "English"
+    },
+    {
+        "en": "Equatoguinean"
+    },
+    {
+        "en": "Equatorial Guinean"
+    },
+    {
+        "en": "Eritrean"
+    },
+    {
+        "en": "Estonian"
+    },
+    {
+        "en": "Ethiopian"
+    },
+    {
+        "en": "European"
+    },
+    {
+        "en": "Falkland Islander"
+    },
+    {
+        "en": "Faroese"
+    },
+    {
+        "en": "Fijian"
+    },
+    {
+        "en": "Filipina"
+    },
+    {
+        "en": "Filipino"
+    },
+    {
+        "en": "Finnish"
+    },
+    {
+        "en": "French"
+    },
+    {
+        "en": "French Polynesian"
+    },
+    {
+        "en": "Futunan"
+    },
+    {
+        "en": "Gabonese"
+    },
+    {
+        "en": "Gambian"
+    },
+    {
+        "en": "Georgian"
+    },
+    {
+        "en": "German"
+    },
+    {
+        "en": "Ghanaian"
+    },
+    {
+        "en": "Gibraltarian"
+    },
+    {
+        "en": "Greek"
+    },
+    {
+        "en": "Greek Cypriot"
+    },
+    {
+        "en": "Greenlandic"
+    },
+    {
+        "en": "Grenadian"
+    },
+    {
+        "en": "Guadeloupean"
+    },
+    {
+        "en": "Guamanian"
+    },
+    {
+        "en": "Guatemalan"
+    },
+    {
+        "en": "Guianan"
+    },
+    {
+        "en": "Guinean (Guinea)"
+    },
+    {
+        "en": "Guinean (Guinea-Bissau)"
+    },
+    {
+        "en": "Guyanese"
+    },
+    {
+        "en": "Haitian"
+    },
+    {
+        "en": "Honduran"
+    },
+    {
+        "en": "Hong Kong Chinese"
+    },
+    {
+        "en": "HongKonger"
+    },
+    {
+        "en": "Hungarian"
+    },
+    {
+        "en": "Icelandic"
+    },
+    {
+        "en": "I-Kiribati"
+    },
+    {
+        "en": "Indian"
+    },
+    {
+        "en": "Indonesian"
+    },
+    {
+        "en": "Iranian"
+    },
+    {
+        "en": "Iraqi"
+    },
+    {
+        "en": "Irish"
+    },
+    {
+        "en": "Israeli"
+    },
+    {
+        "en": "Italian"
+    },
+    {
+        "en": "Ivorian"
+    },
+    {
+        "en": "Jamaican"
+    },
+    {
+        "en": "Japanese"
+    },
+    {
+        "en": "Jordanian"
+    },
+    {
+        "en": "Kazakhstani"
+    },
+    {
+        "en": "Kenyan"
+    },
+    {
+        "en": "Kernewek"
+    },
+    {
+        "en": "Kernouak"
+    },
+    {
+        "en": "Kernowek"
+    },
+    {
+        "en": "Kernowyon"
+    },
+    {
+        "en": "Kittitian"
+    },
+    {
+        "en": "Korean"
+    },
+    {
+        "en": "Kosovan"
+    },
+    {
+        "en": "Kurdish"
+    },
+    {
+        "en": "Kuwaiti"
+    },
+    {
+        "en": "Kyrgyz"
+    },
+    {
+        "en": "Lao"
+    },
+    {
+        "en": "Latvian"
+    },
+    {
+        "en": "Lebanese"
+    },
+    {
+        "en": "Lesothan"
+    },
+    {
+        "en": "Liberian"
+    },
+    {
+        "en": "Libyan"
+    },
+    {
+        "en": "Liechtensteiner"
+    },
+    {
+        "en": "Lithuanian"
+    },
+    {
+        "en": "Luxembourger"
+    },
+    {
+        "en": "Macau"
+    },
+    {
+        "en": "Macedonian"
+    },
+    {
+        "en": "Madagascan"
+    },
+    {
+        "en": "Malawian"
+    },
+    {
+        "en": "Malaysian"
+    },
+    {
+        "en": "Maldivian"
+    },
+    {
+        "en": "Malian"
+    },
+    {
+        "en": "Maltese"
+    },
+    {
+        "en": "Manx"
+    },
+    {
+        "en": "Maori"
+    },
+    {
+        "en": "Marshallese"
+    },
+    {
+        "en": "Martiniquan"
+    },
+    {
+        "en": "Mauritanian"
+    },
+    {
+        "en": "Mauritian"
+    },
+    {
+        "en": "Mexican"
+    },
+    {
+        "en": "Micronesian"
+    },
+    {
+        "en": "Miquelonnais"
+    },
+    {
+        "en": "Moldovan"
+    },
+    {
+        "en": "Monacan"
+    },
+    {
+        "en": "Mongolian"
+    },
+    {
+        "en": "Montenegrin"
+    },
+    {
+        "en": "Montserratian"
+    },
+    {
+        "en": "Moroccan"
+    },
+    {
+        "en": "Motswana"
+    },
+    {
+        "en": "Mozambican"
+    },
+    {
+        "en": "Myanma"
+    },
+    {
+        "en": "Namibian"
+    },
+    {
+        "en": "Nauruan"
+    },
+    {
+        "en": "Nepalese"
+    },
+    {
+        "en": "Nevisian"
+    },
+    {
+        "en": "New Caledonian"
+    },
+    {
+        "en": "New Zealander"
+    },
+    {
+        "en": "Nicaraguan"
+    },
+    {
+        "en": "Nigerian (Nigeria)"
+    },
+    {
+        "en": "Nigerien (Niger)"
+    },
+    {
+        "en": "Niuean"
+    },
+    {
+        "en": "Ni-Vanuatu"
+    },
+    {
+        "en": "Norfolk Islander"
+    },
+    {
+        "en": "North Korean"
+    },
+    {
+        "en": "Northern Irish"
+    },
+    {
+        "en": "Northern Mariana Islander "
+    },
+    {
+        "en": "Norwegian"
+    },
+    {
+        "en": "Omani"
+    },
+    {
+        "en": "Pakistani"
+    },
+    {
+        "en": "Palauan"
+    },
+    {
+        "en": "Palestinian"
+    },
+    {
+        "en": "Panamanian"
+    },
+    {
+        "en": "Papua New Guinean"
+    },
+    {
+        "en": "Paraguayan"
+    },
+    {
+        "en": "Peruvian"
+    },
+    {
+        "en": "Pitcairn Islander"
+    },
+    {
+        "en": "Polish"
+    },
+    {
+        "en": "Portuguese"
+    },
+    {
+        "en": "Puerto Rican"
+    },
+    {
+        "en": "Qatari"
+    },
+    {
+        "en": "Quisqueyan "
+    },
+    {
+        "en": "Réunionese"
+    },
+    {
+        "en": "Romanian"
+    },
+    {
+        "en": "Russian"
+    },
+    {
+        "en": "Rwandan"
+    },
+    {
+        "en": "Sabian"
+    },
+    {
+        "en": "Sahrawi"
+    },
+    {
+        "en": "Saint Helenian"
+    },
+    {
+        "en": "Saint Lucian"
+    },
+    {
+        "en": "Saint Maartener"
+    },
+    {
+        "en": "Saint Vincentian"
+    },
+    {
+        "en": "Saint-Martinois"
+    },
+    {
+        "en": "Saint-Pierrais"
+    },
+    {
+        "en": "Salvadoran"
+    },
+    {
+        "en": "Sammarinese"
+    },
+    {
+        "en": "Samoan"
+    },
+    {
+        "en": "São Toméan"
+    },
+    {
+        "en": "Saudi Arabian"
+    },
+    {
+        "en": "Scottish"
+    },
+    {
+        "en": "Senegalese"
+    },
+    {
+        "en": "Serbian"
+    },
+    {
+        "en": "Seychellois"
+    },
+    {
+        "en": "Sierra Leonean"
+    },
+    {
+        "en": "Singaporean"
+    },
+    {
+        "en": "Slovakian"
+    },
+    {
+        "en": "Slovenian"
+    },
+    {
+        "en": "Solomon Islander"
+    },
+    {
+        "en": "Somali"
+    },
+    {
+        "en": "South African"
+    },
+    {
+        "en": "South Georgian"
+    },
+    {
+        "en": "South Korean"
+    },
+    {
+        "en": "South Sandwich Islander"
+    },
+    {
+        "en": "South Sudanese"
+    },
+    {
+        "en": "Spanish"
+    },
+    {
+        "en": "Sri Lankan"
+    },
+    {
+        "en": "St Helenian"
+    },
+    {
+        "en": "St Lucian"
+    },
+    {
+        "en": "St Maartener"
+    },
+    {
+        "en": "St Vincentian"
+    },
+    {
+        "en": "Statian"
+    },
+    {
+        "en": "Sudanese"
+    },
+    {
+        "en": "Surinamese"
+    },
+    {
+        "en": "Svalbard and Jan Mayen Islander"
+    },
+    {
+        "en": "Swazi"
+    },
+    {
+        "en": "Swedish"
+    },
+    {
+        "en": "Swiss"
+    },
+    {
+        "en": "Syrian"
+    },
+    {
+        "en": "Taiwanese"
+    },
+    {
+        "en": "Tajik"
+    },
+    {
+        "en": "Tanzanian"
+    },
+    {
+        "en": "Thai"
+    },
+    {
+        "en": "Togolese"
+    },
+    {
+        "en": "Tokelauan"
+    },
+    {
+        "en": "Tongan"
+    },
+    {
+        "en": "Trinidadian and Tobagonian"
+    },
+    {
+        "en": "Tunisian"
+    },
+    {
+        "en": "Turkish"
+    },
+    {
+        "en": "Turkish Cypriot"
+    },
+    {
+        "en": "Turkmenistani"
+    },
+    {
+        "en": "Turks and Caicos Islander"
+    },
+    {
+        "en": "Tuvaluan"
+    },
+    {
+        "en": "Ugandan"
+    },
+    {
+        "en": "Ukrainian"
+    },
+    {
+        "en": "Ulster-Scots"
+    },
+    {
+        "en": "Uruguayan"
+    },
+    {
+        "en": "US citizen "
+    },
+    {
+        "en": "Uzbek"
+    },
+    {
+        "en": "Venezuelan"
+    },
+    {
+        "en": "Vietnamese"
+    },
+    {
+        "en": "Vincentian"
+    },
+    {
+        "en": "Virgin Islander"
+    },
+    {
+        "en": "Wallisian"
+    },
+    {
+        "en": "Welsh"
+    },
+    {
+        "en": "Yemeni"
+    },
+    {
+        "en": "Zambian"
+    },
+    {
+        "en": "Zimbabwean"
+    }
 ]

--- a/data/ni/en/passport-countries.json
+++ b/data/ni/en/passport-countries.json
@@ -1,200 +1,596 @@
 [
-    "Afghanistan",
-    "Albania",
-    "Algeria",
-    "Andorra",
-    "Angola",
-    "Antigua and Barbuda",
-    "Argentina",
-    "Armenia",
-    "Australia",
-    "Austria",
-    "Azerbaijan",
-    "Bahrain",
-    "Bangladesh",
-    "Barbados",
-    "Belarus",
-    "Belgium",
-    "Belize",
-    "Benin",
-    "Bhutan",
-    "Bolivia",
-    "Bosnia and Herzegovina",
-    "Botswana",
-    "Brazil",
-    "Brunei",
-    "Bulgaria",
-    "Burkina Faso",
-    "Burundi",
-    "Cambodia",
-    "Cameroon",
-    "Canada",
-    "Cape Verde ",
-    "Chad",
-    "Chile",
-    "China",
-    "Colombia",
-    "Comoros",
-    "Congo",
-    "Congo (Democratic Republic)",
-    "Costa Rica",
-    "Croatia ",
-    "Cuba",
-    "Cyprus",
-    "Czech Republic or Czechia",
-    "Denmark ",
-    "Djibouti",
-    "Dominica",
-    "Dominican Republic ",
-    "East Timor",
-    "Ecuador ",
-    "Egypt",
-    "El Salvador ",
-    "Equatorial Guinea",
-    "Eritrea ",
-    "Estonia ",
-    "Eswatini",
-    "Ethiopia ",
-    "Fiji",
-    "Finland",
-    "France",
-    "Gabon",
-    "Georgia",
-    "Germany",
-    "Ghana",
-    "Greece",
-    "Grenada",
-    "Guatemala",
-    "Guinea",
-    "Guinea-Bissau",
-    "Guyana",
-    "Haiti",
-    "Honduras",
-    "Hong Kong ",
-    "Hungary",
-    "Iceland ",
-    "India",
-    "Indonesia",
-    "Iran",
-    "Iraq",
-    "Ireland",
-    "Israel",
-    "Italy",
-    "Ivory Coast",
-    "Jamaica",
-    "Japan",
-    "Jordan",
-    "Kazakhstan",
-    "Kenya",
-    "Kiribati",
-    "Kosovo",
-    "Kuwait",
-    "Kyrgyzstan",
-    "Laos",
-    "Latvia",
-    "Lebanon",
-    "Lesotho",
-    "Liberia",
-    "Libya",
-    "Liechtenstein",
-    "Lithuania",
-    "Luxembourg",
-    "Macao ",
-    "Madagascar ",
-    "Malawi",
-    "Malaysia",
-    "Maldives",
-    "Mali",
-    "Malta",
-    "Marshall Islands",
-    "Mauritania",
-    "Mauritius",
-    "Mexico",
-    "Micronesia",
-    "Moldova",
-    "Monaco",
-    "Mongolia",
-    "Montenegro",
-    "Morocco",
-    "Mozambique",
-    "Myanmar (Burma)",
-    "Namibia",
-    "Nauru",
-    "Nepal",
-    "New Zealand",
-    "Nicaragua",
-    "Niger",
-    "Nigeria",
-    "North Cyprus",
-    "North Korea",
-    "North Macedonia",
-    "Norway",
-    "Oman",
-    "Pakistan",
-    "Palau",
-    "Panama",
-    "Papua New Guinea",
-    "Paraguay",
-    "Peru",
-    "Philippines",
-    "Poland",
-    "Portugal",
-    "Qatar",
-    "Romania",
-    "Russia",
-    "Rwanda",
-    "Samoa",
-    "San Marino",
-    "São Tomé and Príncipe",
-    "Saudi Arabia",
-    "Senegal",
-    "Serbia",
-    "Seychelles",
-    "Sierra Leone",
-    "Singapore ",
-    "Slovakia",
-    "Slovenia",
-    "Solomon Islands ",
-    "Somalia",
-    "South Africa",
-    "South Korea",
-    "South Sudan",
-    "Spain",
-    "Sri Lanka ",
-    "St Kitts and Nevis",
-    "St Lucia",
-    "St Vincent and the Grenadines",
-    "Sudan",
-    "Suriname",
-    "Sweden",
-    "Switzerland",
-    "Syria",
-    "Taiwan",
-    "Tajikistan",
-    "Tanzania",
-    "Thailand",
-    "The Bahamas",
-    "The Gambia",
-    "The Netherlands",
-    "Togo",
-    "Tonga",
-    "Trinidad and Tobago",
-    "Tunisia",
-    "Turkey",
-    "Turkmenistan",
-    "Tuvalu",
-    "Uganda",
-    "Ukraine",
-    "United Arab Emirates",
-    "United Kingdom",
-    "United States of America",
-    "Uruguay",
-    "Uzbekistan",
-    "Vanuatu",
-    "Vatican City",
-    "Venezuela",
-    "Vietnam",
-    "Yemen",
-    "Zambia",
-    "Zimbabwe"
+    {
+        "en": "Afghanistan"
+    },
+    {
+        "en": "Albania"
+    },
+    {
+        "en": "Algeria"
+    },
+    {
+        "en": "Andorra"
+    },
+    {
+        "en": "Angola"
+    },
+    {
+        "en": "Antigua and Barbuda"
+    },
+    {
+        "en": "Argentina"
+    },
+    {
+        "en": "Armenia"
+    },
+    {
+        "en": "Australia"
+    },
+    {
+        "en": "Austria"
+    },
+    {
+        "en": "Azerbaijan"
+    },
+    {
+        "en": "Bahrain"
+    },
+    {
+        "en": "Bangladesh"
+    },
+    {
+        "en": "Barbados"
+    },
+    {
+        "en": "Belarus"
+    },
+    {
+        "en": "Belgium"
+    },
+    {
+        "en": "Belize"
+    },
+    {
+        "en": "Benin"
+    },
+    {
+        "en": "Bhutan"
+    },
+    {
+        "en": "Bolivia"
+    },
+    {
+        "en": "Bosnia and Herzegovina"
+    },
+    {
+        "en": "Botswana"
+    },
+    {
+        "en": "Brazil"
+    },
+    {
+        "en": "Brunei"
+    },
+    {
+        "en": "Bulgaria"
+    },
+    {
+        "en": "Burkina Faso"
+    },
+    {
+        "en": "Burundi"
+    },
+    {
+        "en": "Cambodia"
+    },
+    {
+        "en": "Cameroon"
+    },
+    {
+        "en": "Canada"
+    },
+    {
+        "en": "Cape Verde "
+    },
+    {
+        "en": "Chad"
+    },
+    {
+        "en": "Chile"
+    },
+    {
+        "en": "China"
+    },
+    {
+        "en": "Colombia"
+    },
+    {
+        "en": "Comoros"
+    },
+    {
+        "en": "Congo"
+    },
+    {
+        "en": "Congo (Democratic Republic)"
+    },
+    {
+        "en": "Costa Rica"
+    },
+    {
+        "en": "Croatia "
+    },
+    {
+        "en": "Cuba"
+    },
+    {
+        "en": "Cyprus"
+    },
+    {
+        "en": "Czech Republic or Czechia"
+    },
+    {
+        "en": "Denmark "
+    },
+    {
+        "en": "Djibouti"
+    },
+    {
+        "en": "Dominica"
+    },
+    {
+        "en": "Dominican Republic "
+    },
+    {
+        "en": "East Timor"
+    },
+    {
+        "en": "Ecuador "
+    },
+    {
+        "en": "Egypt"
+    },
+    {
+        "en": "El Salvador "
+    },
+    {
+        "en": "Equatorial Guinea"
+    },
+    {
+        "en": "Eritrea "
+    },
+    {
+        "en": "Estonia "
+    },
+    {
+        "en": "Eswatini"
+    },
+    {
+        "en": "Ethiopia "
+    },
+    {
+        "en": "Fiji"
+    },
+    {
+        "en": "Finland"
+    },
+    {
+        "en": "France"
+    },
+    {
+        "en": "Gabon"
+    },
+    {
+        "en": "Georgia"
+    },
+    {
+        "en": "Germany"
+    },
+    {
+        "en": "Ghana"
+    },
+    {
+        "en": "Greece"
+    },
+    {
+        "en": "Grenada"
+    },
+    {
+        "en": "Guatemala"
+    },
+    {
+        "en": "Guinea"
+    },
+    {
+        "en": "Guinea-Bissau"
+    },
+    {
+        "en": "Guyana"
+    },
+    {
+        "en": "Haiti"
+    },
+    {
+        "en": "Honduras"
+    },
+    {
+        "en": "Hong Kong "
+    },
+    {
+        "en": "Hungary"
+    },
+    {
+        "en": "Iceland "
+    },
+    {
+        "en": "India"
+    },
+    {
+        "en": "Indonesia"
+    },
+    {
+        "en": "Iran"
+    },
+    {
+        "en": "Iraq"
+    },
+    {
+        "en": "Ireland"
+    },
+    {
+        "en": "Israel"
+    },
+    {
+        "en": "Italy"
+    },
+    {
+        "en": "Ivory Coast"
+    },
+    {
+        "en": "Jamaica"
+    },
+    {
+        "en": "Japan"
+    },
+    {
+        "en": "Jordan"
+    },
+    {
+        "en": "Kazakhstan"
+    },
+    {
+        "en": "Kenya"
+    },
+    {
+        "en": "Kiribati"
+    },
+    {
+        "en": "Kosovo"
+    },
+    {
+        "en": "Kuwait"
+    },
+    {
+        "en": "Kyrgyzstan"
+    },
+    {
+        "en": "Laos"
+    },
+    {
+        "en": "Latvia"
+    },
+    {
+        "en": "Lebanon"
+    },
+    {
+        "en": "Lesotho"
+    },
+    {
+        "en": "Liberia"
+    },
+    {
+        "en": "Libya"
+    },
+    {
+        "en": "Liechtenstein"
+    },
+    {
+        "en": "Lithuania"
+    },
+    {
+        "en": "Luxembourg"
+    },
+    {
+        "en": "Macao "
+    },
+    {
+        "en": "Madagascar "
+    },
+    {
+        "en": "Malawi"
+    },
+    {
+        "en": "Malaysia"
+    },
+    {
+        "en": "Maldives"
+    },
+    {
+        "en": "Mali"
+    },
+    {
+        "en": "Malta"
+    },
+    {
+        "en": "Marshall Islands"
+    },
+    {
+        "en": "Mauritania"
+    },
+    {
+        "en": "Mauritius"
+    },
+    {
+        "en": "Mexico"
+    },
+    {
+        "en": "Micronesia"
+    },
+    {
+        "en": "Moldova"
+    },
+    {
+        "en": "Monaco"
+    },
+    {
+        "en": "Mongolia"
+    },
+    {
+        "en": "Montenegro"
+    },
+    {
+        "en": "Morocco"
+    },
+    {
+        "en": "Mozambique"
+    },
+    {
+        "en": "Myanmar (Burma)"
+    },
+    {
+        "en": "Namibia"
+    },
+    {
+        "en": "Nauru"
+    },
+    {
+        "en": "Nepal"
+    },
+    {
+        "en": "New Zealand"
+    },
+    {
+        "en": "Nicaragua"
+    },
+    {
+        "en": "Niger"
+    },
+    {
+        "en": "Nigeria"
+    },
+    {
+        "en": "North Cyprus"
+    },
+    {
+        "en": "North Korea"
+    },
+    {
+        "en": "North Macedonia"
+    },
+    {
+        "en": "Norway"
+    },
+    {
+        "en": "Oman"
+    },
+    {
+        "en": "Pakistan"
+    },
+    {
+        "en": "Palau"
+    },
+    {
+        "en": "Panama"
+    },
+    {
+        "en": "Papua New Guinea"
+    },
+    {
+        "en": "Paraguay"
+    },
+    {
+        "en": "Peru"
+    },
+    {
+        "en": "Philippines"
+    },
+    {
+        "en": "Poland"
+    },
+    {
+        "en": "Portugal"
+    },
+    {
+        "en": "Qatar"
+    },
+    {
+        "en": "Romania"
+    },
+    {
+        "en": "Russia"
+    },
+    {
+        "en": "Rwanda"
+    },
+    {
+        "en": "Samoa"
+    },
+    {
+        "en": "San Marino"
+    },
+    {
+        "en": "São Tomé and Príncipe"
+    },
+    {
+        "en": "Saudi Arabia"
+    },
+    {
+        "en": "Senegal"
+    },
+    {
+        "en": "Serbia"
+    },
+    {
+        "en": "Seychelles"
+    },
+    {
+        "en": "Sierra Leone"
+    },
+    {
+        "en": "Singapore "
+    },
+    {
+        "en": "Slovakia"
+    },
+    {
+        "en": "Slovenia"
+    },
+    {
+        "en": "Solomon Islands "
+    },
+    {
+        "en": "Somalia"
+    },
+    {
+        "en": "South Africa"
+    },
+    {
+        "en": "South Korea"
+    },
+    {
+        "en": "South Sudan"
+    },
+    {
+        "en": "Spain"
+    },
+    {
+        "en": "Sri Lanka "
+    },
+    {
+        "en": "St Kitts and Nevis"
+    },
+    {
+        "en": "St Lucia"
+    },
+    {
+        "en": "St Vincent and the Grenadines"
+    },
+    {
+        "en": "Sudan"
+    },
+    {
+        "en": "Suriname"
+    },
+    {
+        "en": "Sweden"
+    },
+    {
+        "en": "Switzerland"
+    },
+    {
+        "en": "Syria"
+    },
+    {
+        "en": "Taiwan"
+    },
+    {
+        "en": "Tajikistan"
+    },
+    {
+        "en": "Tanzania"
+    },
+    {
+        "en": "Thailand"
+    },
+    {
+        "en": "The Bahamas"
+    },
+    {
+        "en": "The Gambia"
+    },
+    {
+        "en": "The Netherlands"
+    },
+    {
+        "en": "Togo"
+    },
+    {
+        "en": "Tonga"
+    },
+    {
+        "en": "Trinidad and Tobago"
+    },
+    {
+        "en": "Tunisia"
+    },
+    {
+        "en": "Turkey"
+    },
+    {
+        "en": "Turkmenistan"
+    },
+    {
+        "en": "Tuvalu"
+    },
+    {
+        "en": "Uganda"
+    },
+    {
+        "en": "Ukraine"
+    },
+    {
+        "en": "United Arab Emirates"
+    },
+    {
+        "en": "United Kingdom"
+    },
+    {
+        "en": "United States of America"
+    },
+    {
+        "en": "Uruguay"
+    },
+    {
+        "en": "Uzbekistan"
+    },
+    {
+        "en": "Vanuatu"
+    },
+    {
+        "en": "Vatican City"
+    },
+    {
+        "en": "Venezuela"
+    },
+    {
+        "en": "Vietnam"
+    },
+    {
+        "en": "Yemen"
+    },
+    {
+        "en": "Zambia"
+    },
+    {
+        "en": "Zimbabwe"
+    }
 ]

--- a/data/ni/en/religions.json
+++ b/data/ni/en/religions.json
@@ -1,107 +1,317 @@
 [
-    "Agnostic",
-    "Ahmadi Muslim",
-    "Alevi",
-    "Anglican",
-    "Apostolic Church",
-    "Bahai",
-    "Baptist",
-    "Born Again Christian",
-    "Brethren",
-    "Buddhist",
-    "Catholic",
-    "Charismatic Church",
-    "Christadelphian",
-    "Christian",
-    "Christian Fellowship",
-    "Christian Fellowship Church",
-    "Christian Orthodox",
-    "Christian Scientist",
-    "Church in Wales",
-    "Church of Christ",
-    "Church of England",
-    "Church of God",
-    "Church of Ireland ",
-    "Church Of Jesus Christ Of Latter Day Saints ",
-    "Church of Scotland",
-    "Church Of The Nazarene",
-    "City Mission",
-    "Congregational Church",
-    "Coptic Orthodox",
-    "Deist",
-    "Dutch Reformed Church",
-    "Eastern Orthodox Church",
-    "Elim Pentecostal Church",
-    "Episcopalian",
-    "Evangelical",
-    "Evangelical Presbyterian Church",
-    "Free Church Of Scotland",
-    "Free Evangelical Church",
-    "Free Methodist",
-    "Free Presbyterian",
-    "Free Presbyterian Church Of Scotland",
-    "Gnostic",
-    "Greek Orthodox",
-    "Hare Krishna",
-    "Hindu",
-    "Holistic",
-    "House Church",
-    "Independent",
-    "Independent Evangelist",
-    "Independent Methodist",
-    "Interdenominational",
-    "International Society For Krishna Consciousness",
-    "Islam ",
-    "Jain",
-    "Jehovah's Witness",
-    "Jewish",
-    "Kirat",
-    "Latter Day Saint",
-    "Lutheran",
-    "Methodist",
-    "Methodist Church in Ireland",
-    "Metropolitan Church",
-    "Mixed Catholic/Protestant",
-    "Mixed Religion",
-    "Moravian",
-    "Mormon",
-    "Muslim",
-    "No Religion",
-    "Non Denominational",
-    "Non-Subscribing Presbyterian",
-    "Orthodox Church",
-    "Pantheism",
-    "Pantheist",
-    "Pentecostal",
-    "Presbyterian",
-    "Presbyterian Church in Ireland ",
-    "Protestant",
-    "Protestant (Mixed)",
-    "Quaker",
-    "Rastafarian",
-    "Ravidassia",
-    "Reformed",
-    "Reformed Presbyterian",
-    "Religious Society Of Friends ",
-    "Roman Catholic",
-    "Romanian Orthodox Church",
-    "Russian Orthodox Church",
-    "Salvation Army",
-    "Scottish Presbyterian",
-    "Serbian Orthodox",
-    "Seventh Day Adventist",
-    "Shinto",
-    "Sikh",
-    "Spiritual",
-    "Spiritualist",
-    "Taoist",
-    "Theist",
-    "Unitarian",
-    "United Reformed Church",
-    "Welsh Baptist",
-    "Whitewell Metropolitan Tabernacle",
-    "Wiccan",
-    "Yazidi",
-    "Yezidi",
-    "Zoroastrian"
+    {
+        "en": "Agnostic"
+    },
+    {
+        "en": "Ahmadi Muslim"
+    },
+    {
+        "en": "Alevi"
+    },
+    {
+        "en": "Anglican"
+    },
+    {
+        "en": "Apostolic Church"
+    },
+    {
+        "en": "Bahai"
+    },
+    {
+        "en": "Baptist"
+    },
+    {
+        "en": "Born Again Christian"
+    },
+    {
+        "en": "Brethren"
+    },
+    {
+        "en": "Buddhist"
+    },
+    {
+        "en": "Catholic"
+    },
+    {
+        "en": "Charismatic Church"
+    },
+    {
+        "en": "Christadelphian"
+    },
+    {
+        "en": "Christian"
+    },
+    {
+        "en": "Christian Fellowship"
+    },
+    {
+        "en": "Christian Fellowship Church"
+    },
+    {
+        "en": "Christian Orthodox"
+    },
+    {
+        "en": "Christian Scientist"
+    },
+    {
+        "en": "Church in Wales"
+    },
+    {
+        "en": "Church of Christ"
+    },
+    {
+        "en": "Church of England"
+    },
+    {
+        "en": "Church of God"
+    },
+    {
+        "en": "Church of Ireland "
+    },
+    {
+        "en": "Church Of Jesus Christ Of Latter Day Saints "
+    },
+    {
+        "en": "Church of Scotland"
+    },
+    {
+        "en": "Church Of The Nazarene"
+    },
+    {
+        "en": "City Mission"
+    },
+    {
+        "en": "Congregational Church"
+    },
+    {
+        "en": "Coptic Orthodox"
+    },
+    {
+        "en": "Deist"
+    },
+    {
+        "en": "Dutch Reformed Church"
+    },
+    {
+        "en": "Eastern Orthodox Church"
+    },
+    {
+        "en": "Elim Pentecostal Church"
+    },
+    {
+        "en": "Episcopalian"
+    },
+    {
+        "en": "Evangelical"
+    },
+    {
+        "en": "Evangelical Presbyterian Church"
+    },
+    {
+        "en": "Free Church Of Scotland"
+    },
+    {
+        "en": "Free Evangelical Church"
+    },
+    {
+        "en": "Free Methodist"
+    },
+    {
+        "en": "Free Presbyterian"
+    },
+    {
+        "en": "Free Presbyterian Church Of Scotland"
+    },
+    {
+        "en": "Gnostic"
+    },
+    {
+        "en": "Greek Orthodox"
+    },
+    {
+        "en": "Hare Krishna"
+    },
+    {
+        "en": "Hindu"
+    },
+    {
+        "en": "Holistic"
+    },
+    {
+        "en": "House Church"
+    },
+    {
+        "en": "Independent"
+    },
+    {
+        "en": "Independent Evangelist"
+    },
+    {
+        "en": "Independent Methodist"
+    },
+    {
+        "en": "Interdenominational"
+    },
+    {
+        "en": "International Society For Krishna Consciousness"
+    },
+    {
+        "en": "Islam "
+    },
+    {
+        "en": "Jain"
+    },
+    {
+        "en": "Jehovah's Witness"
+    },
+    {
+        "en": "Jewish"
+    },
+    {
+        "en": "Kirat"
+    },
+    {
+        "en": "Latter Day Saint"
+    },
+    {
+        "en": "Lutheran"
+    },
+    {
+        "en": "Methodist"
+    },
+    {
+        "en": "Methodist Church in Ireland"
+    },
+    {
+        "en": "Metropolitan Church"
+    },
+    {
+        "en": "Mixed Catholic/Protestant"
+    },
+    {
+        "en": "Mixed Religion"
+    },
+    {
+        "en": "Moravian"
+    },
+    {
+        "en": "Mormon"
+    },
+    {
+        "en": "Muslim"
+    },
+    {
+        "en": "No Religion"
+    },
+    {
+        "en": "Non Denominational"
+    },
+    {
+        "en": "Non-Subscribing Presbyterian"
+    },
+    {
+        "en": "Orthodox Church"
+    },
+    {
+        "en": "Pantheism"
+    },
+    {
+        "en": "Pantheist"
+    },
+    {
+        "en": "Pentecostal"
+    },
+    {
+        "en": "Presbyterian"
+    },
+    {
+        "en": "Presbyterian Church in Ireland "
+    },
+    {
+        "en": "Protestant"
+    },
+    {
+        "en": "Protestant (Mixed)"
+    },
+    {
+        "en": "Quaker"
+    },
+    {
+        "en": "Rastafarian"
+    },
+    {
+        "en": "Ravidassia"
+    },
+    {
+        "en": "Reformed"
+    },
+    {
+        "en": "Reformed Presbyterian"
+    },
+    {
+        "en": "Religious Society Of Friends "
+    },
+    {
+        "en": "Roman Catholic"
+    },
+    {
+        "en": "Romanian Orthodox Church"
+    },
+    {
+        "en": "Russian Orthodox Church"
+    },
+    {
+        "en": "Salvation Army"
+    },
+    {
+        "en": "Scottish Presbyterian"
+    },
+    {
+        "en": "Serbian Orthodox"
+    },
+    {
+        "en": "Seventh Day Adventist"
+    },
+    {
+        "en": "Shinto"
+    },
+    {
+        "en": "Sikh"
+    },
+    {
+        "en": "Spiritual"
+    },
+    {
+        "en": "Spiritualist"
+    },
+    {
+        "en": "Taoist"
+    },
+    {
+        "en": "Theist"
+    },
+    {
+        "en": "Unitarian"
+    },
+    {
+        "en": "United Reformed Church"
+    },
+    {
+        "en": "Welsh Baptist"
+    },
+    {
+        "en": "Whitewell Metropolitan Tabernacle"
+    },
+    {
+        "en": "Wiccan"
+    },
+    {
+        "en": "Yazidi"
+    },
+    {
+        "en": "Yezidi"
+    },
+    {
+        "en": "Zoroastrian"
+    }
 ]

--- a/scripts/convert_csv_to_json.py
+++ b/scripts/convert_csv_to_json.py
@@ -34,7 +34,7 @@ def generate_json_files():
 
                     with open(source_file_location, newline='') as csv_file:
                         for row in csv.DictReader(csv_file, fieldnames=['term']):
-                            json_data.append(row.get('term'))
+                            json_data.append({language_directory_name: row.get('term')})
                     try:
                         with open(output_file_location, 'w', encoding='utf8') as f:
                             json.dump(json_data, f, indent=4, ensure_ascii=False)


### PR DESCRIPTION
### Context
Reverts a recent change and reintroduces the language keys for the lookup suggestions files. This is because a bug exists in IE11 meaning that data files with an array of strings are not currently supported by the latest version Fuse, see the Trello card for more details.

The lookup files will contain an array of {key:value} objects.

### How to Review
Check all the data files have been updated.
Check the script produces files with an array of {key:value} objects



