### PR TITLE
Fix typo in NI ethnic groups list

### DIFF
--- a/source-data/ni/en/ethnic-groups.csv
+++ b/source-data/ni/en/ethnic-groups.csv
@@ -36,7 +36,7 @@ Scottish
 Sri Lankan
 Thai
 Turkish
-Ulster-Scot
+Ulster-Scots
 Vietnamese
 Welsh
 White


### PR DESCRIPTION
### Context

Updates the NI `ethnic-groups` list to fix a typo, `ulster-scot` should be `ulster-scots`

### How to Review

Check the list has been updated