### PR TITLE
Update Codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @ONSdigital/eq-runner
+* @ONSdigital/census-eq
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eQ Lookup Suggestions Data
 
-This repository contains TextField suggestion data source files used for versioned json files generation for eq-questionnaire-runner.
+This repository contains TextField suggestion data source files used for versioned json files generation for census31-eq-questionnaire-runner.
 
 ## Source csv files
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eQ Lookup Suggestions Data
+# Census 31 eQ Lookup Suggestions Data
 
 This repository contains TextField suggestion data source files used for versioned json files generation for census31-eq-questionnaire-runner.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = "eq-lookup-suggestions-data"
+name = "census31-eq-lookup-suggestions-data"
 version = "1.0.0"
-description = "ONS Digital eQ Lookup Suggestions Data App"
+description = "Census 31 eQ Lookup Suggestions Data App"
 authors = ["ONSDigital"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
### What is the context of this PR?
Updates the Codeowners file to make the census-eq team the code owners of this repo. Also updates the documentation to reflect the new census repo name

### How to review
- Check the right team has been added to the codeowners file
- Documentation makes sense and no references to the original repo name have been missed
