### PR TITLE
CTE-108: Update EditorConfig Python rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,7 +32,7 @@ trim_trailing_whitespace = true
 # Possible values - true, false
 insert_final_newline = true
 
-[*.{py}]
+[*.py]
 max_line_length = 120
 
 [*.{md,yaml,yml}]


### PR DESCRIPTION
### What is the context of this PR?

[CTE-108](https://officefornationalstatistics.atlassian.net/browse/CTE-108)

Updates the EditorConfig Python max line length rule. This wasn't being enforced because of the curly brackets so this PR removes them

### How to review
Changes make sense, linting passes
